### PR TITLE
Modify Snitch integer core to have CSR decoding

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,6 +85,7 @@ jobs:
             sw/math/src/internal/*
             sw/math/src/math/*
             sw/math/Makefile
+            hw/snitch/src/csr_snax_def.sv
 
   ##################
   # Lint YML Files #

--- a/Bender.yml
+++ b/Bender.yml
@@ -138,6 +138,7 @@ sources:
       # Level 0
       - hw/snitch/src/snitch_pma_pkg.sv
       - hw/snitch/src/riscv_instr.sv
+      - hw/snitch/src/csr_snax_def.sv
       # Level 1
       - hw/snitch/src/snitch_pkg.sv
       # Level 2

--- a/hw/snitch/src/csr_snax_def.sv
+++ b/hw/snitch/src/csr_snax_def.sv
@@ -1,7 +1,6 @@
-  
-  // verilog_lint: waive-start parameter-name-style
-  package csr_snax_def;
-  localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
-  localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
-  endpackage
-  // verilog_lint: waive-stop parameter-name-style
+// verilog_lint: waive-start parameter-name-style
+package csr_snax_def;
+localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
+localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
+endpackage
+// verilog_lint: waive-stop parameter-name-style

--- a/hw/snitch/src/csr_snax_def.sv
+++ b/hw/snitch/src/csr_snax_def.sv
@@ -1,0 +1,7 @@
+  
+  // verilog_lint: waive-start parameter-name-style
+  package csr_snax_def;
+  localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
+  localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
+  endpackage
+  // verilog_lint: waive-stop parameter-name-style

--- a/hw/snitch/src/riscv_instr.sv
+++ b/hw/snitch/src/riscv_instr.sv
@@ -1198,5 +1198,8 @@ package riscv_instr;
   localparam logic [11:0] CSR_MHPMCOUNTER29H = 12'hb9d;
   localparam logic [11:0] CSR_MHPMCOUNTER30H = 12'hb9e;
   localparam logic [11:0] CSR_MHPMCOUNTER31H = 12'hb9f;
+  // SNAX address range
+  localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
+  localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
 endpackage
 // verilog_lint: waive-stop parameter-name-style

--- a/hw/snitch/src/riscv_instr.sv
+++ b/hw/snitch/src/riscv_instr.sv
@@ -1198,8 +1198,5 @@ package riscv_instr;
   localparam logic [11:0] CSR_MHPMCOUNTER29H = 12'hb9d;
   localparam logic [11:0] CSR_MHPMCOUNTER30H = 12'hb9e;
   localparam logic [11:0] CSR_MHPMCOUNTER31H = 12'hb9f;
-  // SNAX address range
-  localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
-  localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
 endpackage
 // verilog_lint: waive-stop parameter-name-style

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -125,9 +125,10 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   logic wfi_d, wfi_q;
   logic [31:0] consec_pc;
   // Immediates
-  logic [31:0] iimm, uimm, jimm, bimm, simm;
+  logic [31:0] iimm, uimm, jimm, bimm, simm, csrimm;
   /* verilator lint_off WIDTH */
   assign iimm = $signed({inst_data_i[31:20]});
+  assign csrimm = {inst_data_i[31:20]};
   assign uimm = {inst_data_i[31:12], 12'b0};
   assign jimm = $signed({inst_data_i[31],
                                   inst_data_i[19:12], inst_data_i[20], inst_data_i[30:21], 1'b0});
@@ -212,7 +213,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   alu_op_e alu_op;
 
   typedef enum logic [3:0] {
-    None, Reg, IImmediate, UImmediate, JImmediate, SImmediate, SFImmediate, PC, CSR, CSRImmmediate
+    None, Reg, IImmediate, UImmediate, JImmediate, SImmediate, SFImmediate, PC, CSR, CSRImmmediate, CSRAddrImmediate
   } op_select_e;
   op_select_e opa_select, opb_select;
 
@@ -757,64 +758,124 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
         opa_select = Reg;
         opb_select = IImmediate;
       end
+
+      //---------------------------------------------
       // CSR Instructions
+      //---------------------------------------------
+
       CSRRW: begin // Atomic Read/Write CSR
-        opa_select = Reg;
-        opb_select = None;
-        rd_select = RdBypass;
-        rd_bypass = csr_rvalue;
-        csr_en = valid_instr;
+        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+          acc_qvalid_o    = valid_instr;
+          opa_select      = Reg;
+          opb_select      = CSRAddrImmediate;
+          acc_qreq_o.addr = SNAX_CSR;
+        end else begin
+          opa_select      = Reg;
+          opb_select      = None;
+          rd_select       = RdBypass;
+          rd_bypass       = csr_rvalue;
+          csr_en          = valid_instr;
+        end
       end
+
       CSRRWI: begin
-        opa_select = CSRImmmediate;
-        opb_select = None;
-        rd_select = RdBypass;
-        rd_bypass = csr_rvalue;
-        csr_en = valid_instr;
+        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+          acc_qvalid_o    = valid_instr;
+          opa_select      = CSRImmmediate;
+          opb_select      = CSRAddrImmediate;
+          acc_qreq_o.addr = SNAX_CSR;
+        end else begin
+          opa_select      = CSRImmmediate;
+          opb_select      = None;
+          rd_select       = RdBypass;
+          rd_bypass       = csr_rvalue;
+          csr_en          = valid_instr;
+        end
       end
+
       CSRRS: begin  // Atomic Read and Set Bits in CSR
-          alu_op = LOr;
-          opa_select = Reg;
-          opb_select = CSR;
-          rd_select = RdBypass;
-          rd_bypass = csr_rvalue;
-          csr_en = valid_instr;
+        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+          write_rd        = 1'b0;
+          uses_rd         = 1'b1;
+          acc_qvalid_o    = valid_instr;
+          opa_select      = None;
+          opb_select      = CSRAddrImmediate; // Just reading so nothing to write
+          acc_register_rd = 1'b1;
+          acc_qreq_o.addr = SNAX_CSR;
+        end else begin
+          alu_op          = LOr;
+          opa_select      = Reg;
+          opb_select      = CSR;
+          rd_select       = RdBypass;
+          rd_bypass       = csr_rvalue;
+          csr_en          = valid_instr;
+        end
       end
+
       CSRRSI: begin
-        // offload CSR enable to FP SS
-        if (inst_data_i[31:20] != CSR_SSR) begin
-          alu_op = LOr;
-          opa_select = CSRImmmediate;
-          opb_select = CSR;
-          rd_select = RdBypass;
-          rd_bypass = csr_rvalue;
-          csr_en = valid_instr;
+        
+        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+          write_rd        = 1'b0;
+          uses_rd         = 1'b1;
+          acc_qvalid_o    = valid_instr;
+          opa_select      = None;
+          opb_select      = CSRAddrImmediate; // Just reading so nothing to write
+          acc_register_rd = 1'b1;
+          acc_qreq_o.addr = SNAX_CSR;
+        end else if (inst_data_i[31:20] != CSR_SSR) begin // offload CSR enable to FP SS
+          alu_op          = LOr;
+          opa_select      = CSRImmmediate;
+          opb_select      = CSR;
+          rd_select       = RdBypass;
+          rd_bypass       = csr_rvalue;
+          csr_en          = valid_instr;
         end else begin
           write_rd = 1'b0;
-          acc_qvalid_o = valid_instr;
+          acc_qvalid_o    = valid_instr;
         end
       end
+
       CSRRC: begin // Atomic Read and Clear Bits in CSR
-        alu_op = LNAnd;
-        opa_select = Reg;
-        opb_select = CSR;
-        rd_select = RdBypass;
-        rd_bypass = csr_rvalue;
-        csr_en = valid_instr;
-      end
-      CSRRCI: begin
-        if (inst_data_i[31:20] != CSR_SSR) begin
-          alu_op = LNAnd;
-          opa_select = CSRImmmediate;
-          opb_select = CSR;
-          rd_select = RdBypass;
-          rd_bypass = csr_rvalue;
-          csr_en = valid_instr;
+        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+          write_rd        = 1'b0;
+          uses_rd         = 1'b1;
+          acc_qvalid_o    = valid_instr;
+          opa_select      = None;
+          opb_select      = CSRAddrImmediate; // Just reading so nothing to write
+          acc_register_rd = 1'b1;
+          acc_qreq_o.addr = SNAX_CSR;
         end else begin
-          write_rd = 1'b0;
-          acc_qvalid_o = valid_instr;
+          alu_op          = LNAnd;
+          opa_select      = Reg;
+          opb_select      = CSR;
+          rd_select       = RdBypass;
+          rd_bypass       = csr_rvalue;
+          csr_en          = valid_instr;
         end
       end
+
+      CSRRCI: begin
+        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+          write_rd        = 1'b0;
+          uses_rd         = 1'b1;
+          acc_qvalid_o    = valid_instr;
+          opa_select      = None;
+          opb_select      = CSRAddrImmediate; // Just reading so nothing to write
+          acc_register_rd = 1'b1;
+          acc_qreq_o.addr = SNAX_CSR;
+        end else if (inst_data_i[31:20] != CSR_SSR) begin
+          alu_op          = LNAnd;
+          opa_select      = CSRImmmediate;
+          opb_select      = CSR;
+          rd_select       = RdBypass;
+          rd_bypass       = csr_rvalue;
+          csr_en          = valid_instr;
+        end else begin
+          write_rd        = 1'b0;
+          acc_qvalid_o    = valid_instr;
+        end
+      end
+
       ECALL: ecall = 1'b1;
       EBREAK: ebreak = 1'b1;
       // Environment return

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -764,7 +764,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       //---------------------------------------------
 
       CSRRW: begin // Atomic Read/Write CSR
-        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           acc_qvalid_o    = valid_instr;
           opa_select      = Reg;
           opb_select      = CSRAddrImmediate;
@@ -779,7 +779,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRWI: begin
-        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           acc_qvalid_o    = valid_instr;
           opa_select      = CSRImmmediate;
           opb_select      = CSRAddrImmediate;
@@ -794,7 +794,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRS: begin  // Atomic Read and Set Bits in CSR
-        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;
@@ -814,7 +814,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
 
       CSRRSI: begin
         
-        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;
@@ -836,7 +836,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRC: begin // Atomic Read and Clear Bits in CSR
-        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;
@@ -855,7 +855,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRCI: begin
-        if((csrimm >= CSR_SNAX_BEGIN) && ((csrimm <= CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -2673,6 +2673,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       SFImmediate, SImmediate: opb = simm;
       PC: opb = pc_q;
       CSR: opb = csr_rvalue;
+      CSRAddrImmediate: opb = csrimm;
       default: opb = '0;
     endcase
   end

--- a/hw/snitch/src/snitch.sv
+++ b/hw/snitch/src/snitch.sv
@@ -213,7 +213,9 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   alu_op_e alu_op;
 
   typedef enum logic [3:0] {
-    None, Reg, IImmediate, UImmediate, JImmediate, SImmediate, SFImmediate, PC, CSR, CSRImmmediate, CSRAddrImmediate
+    None, Reg, IImmediate, UImmediate, JImmediate,
+    SImmediate, SFImmediate, PC,
+    CSR, CSRImmmediate, CSRAddrImmediate
   } op_select_e;
   op_select_e opa_select, opb_select;
 
@@ -764,7 +766,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       //---------------------------------------------
 
       CSRRW: begin // Atomic Read/Write CSR
-        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) &&
+          ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           acc_qvalid_o    = valid_instr;
           opa_select      = Reg;
           opb_select      = CSRAddrImmediate;
@@ -779,7 +782,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRWI: begin
-        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) &&
+          ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           acc_qvalid_o    = valid_instr;
           opa_select      = CSRImmmediate;
           opb_select      = CSRAddrImmediate;
@@ -794,7 +798,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRS: begin  // Atomic Read and Set Bits in CSR
-        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) &&
+          ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;
@@ -813,8 +818,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRSI: begin
-        
-        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) &&
+          ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;
@@ -836,7 +841,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRC: begin // Atomic Read and Clear Bits in CSR
-        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) &&
+          ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;
@@ -855,7 +861,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
 
       CSRRCI: begin
-        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) && ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
+        if((csrimm >= csr_snax_def::CSR_SNAX_BEGIN) &&
+          ((csrimm <= csr_snax_def::CSR_SNAX_END))) begin
           write_rd        = 1'b0;
           uses_rd         = 1'b1;
           acc_qvalid_o    = valid_instr;

--- a/hw/snitch/src/snitch_pkg.sv
+++ b/hw/snitch/src/snitch_pkg.sv
@@ -35,7 +35,8 @@ package snitch_pkg;
     SHARED_MULDIV = 1,
     DMA_SS = 2,
     INT_SS = 3,
-    SSR_CFG = 4
+    SSR_CFG = 4,
+    SNAX_CSR = 5
   } acc_addr_e;
 
   typedef enum logic [1:0] {


### PR DESCRIPTION
This PR changes the CSR decoding of the Snitch integer core to support offloading of instructions to an accelerator. 

In this PR we have:
- **Add an extra SNAX_CSR address selection in snitch_pkg.sv**. The accelerator request and response ports use this for demuxing and arbitration at the core cluster level.
- **Add extra decoding for CSR instructions in the snitch.sv file**. Also add modifications to the MUX-ing that get offloaded into the accelerator request and response ports. 
  - Note that some lines are broken into multiple lines to avoid line-length warnings from lint.
- **A decoupled definition for CSR addresses to be used by SNAX**. This is a special case because there is an opcode checker in CI that modifying riscv_instr.sv file will complain if we add additional definitions that were not part of the original Snitch core definitions. Check [generate-opcodes.sh](https://github.com/KULeuven-MICAS/snitch_cluster/blob/main/util/generate-opcodes.sh) file for more details. I suggest the decouple works for now and we can rectify this more elegantly later.
- **Add the additional csr_snax_def.sv to bender**.
- **Add csr_snax_def.sv to the license checking exclude list**. This is because ETHZ's license checker checks ALL .sv files. Even without licensing it still complains. Should be a minor concern because it's just licensing but we can rectify later.

**To avoid over-cluttering this PR, the next PR will add modification at the core cluster level.** 