### PR TITLE
Refactor simple mac examples

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
           # (mostly for SW) and Solderpad for the hardware.
           # yamllint disable rule:line-length
           license: |
-            Copyright (\d{4}(-\d{4})?\s)?(ETH Zurich and University of Bologna|lowRISC contributors).
+            Copyright (\d{4}(-\d{4})?\s)?(ETH Zurich and University of Bologna|lowRISC contributors|KU Leuven).
             (Solderpad Hardware License, Version 0.51|Licensed under the Apache License, Version 2.0), see LICENSE for details.
             SPDX-License-Identifier: (SHL-0.51|Apache-2.0)
           # yamllint enable rule:line-length

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -14,20 +14,21 @@ RUNTIME = runtime/rtl
 endif
 
 MATH = ../../../sw/math
+SNAX = snax/mac
 
-SUBDIRS = runtime/banshee runtime/rtl $(MATH) apps tests
+SUBDIRS = runtime/banshee runtime/rtl $(SNAX) $(MATH) apps tests 
 
 .PHONY: all $(SUBDIRS)
 
 all: $(SUBDIRS)
 
 # Explicit dependency of apps on runtime
-apps: $(RUNTIME) $(MATH)
+apps: $(RUNTIME) $(SNAX) $(MATH)
 	$(MAKE) -C $@ TARGET=$(TARGET)
 
 # Explicit dependency of tests on runtime
 tests: $(RUNTIME) $(MATH)
 	$(MAKE) -C $@ $(TARGET)
 
-runtime/rtl runtime/banshee $(MATH):
+runtime/rtl runtime/banshee $(MATH) $(SNAX):
 	$(MAKE) -C $@ $(TARGET)

--- a/target/snitch_cluster/sw/Makefile
+++ b/target/snitch_cluster/sw/Makefile
@@ -23,11 +23,11 @@ SUBDIRS = runtime/banshee runtime/rtl $(SNAX) $(MATH) apps tests
 all: $(SUBDIRS)
 
 # Explicit dependency of apps on runtime
-apps: $(RUNTIME) $(SNAX) $(MATH)
+apps: $(RUNTIME) $(MATH) $(SNAX)
 	$(MAKE) -C $@ TARGET=$(TARGET)
 
 # Explicit dependency of tests on runtime
-tests: $(RUNTIME) $(MATH)
+tests: $(RUNTIME) $(MATH) $(SNAX)
 	$(MAKE) -C $@ $(TARGET)
 
 runtime/rtl runtime/banshee $(MATH) $(SNAX):

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/Makefile
@@ -10,6 +10,10 @@ MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 SRC_DIR  := $(realpath $(MK_DIR)/$(APP)/src)
 
 INCDIRS += $(SRC_DIR)
+INCDIRS += ../../../snax/mac/include
+
+# Include this binary in the final build
+RISCV_LDFLAGS += ../../../snax/mac/build/mac.o
 
 SRCS     = $(realpath $(SRC_DIR)/$(APP).c)
 
@@ -22,6 +26,10 @@ $(DATA_H): $(MK_DIR)/datagen.py
 	$< --length=$(LENGTH) --tile_size=$(TILE_SIZE) > $@
 
 .PHONY: clean-data clean
+
+# Call the different makefile in case mac.o is not yet built
+mac.o:
+	$(MAKE) -C $(MK_DIR)../snax/mac/
 
 clean-data:
 	rm -f $(DATA_H)

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/Makefile
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/Makefile
@@ -27,10 +27,6 @@ $(DATA_H): $(MK_DIR)/datagen.py
 
 .PHONY: clean-data clean
 
-# Call the different makefile in case mac.o is not yet built
-mac.o:
-	$(MAKE) -C $(MK_DIR)../snax/mac/
-
 clean-data:
 	rm -f $(DATA_H)
 

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
@@ -6,82 +6,8 @@
 // Ryan Antonio <rgantonio@esat.kuleuven.be>
 
 #include "snrt.h"
-
+#include "mac.h"
 #include "data.h"
-
-// * mac_mode = 0
-//   performs multiply-accumulate over elements to perform dot product
-// * simple_mult_mode = 1
-//   performs simple elementwise multiplication
-enum mode { mac_mode, simple_mult_mode };
-
-void snax_mac_launch() {
-    // Write start CSR to launch accelerator
-    write_csr(0x3c0, 0);
-}
-
-void snax_mac_sw_clear() {
-    // write 0x3c5 to clear HWPE accelerator
-    // Otherwise the accelerator goes into undefined behaviour:
-    // It might stall/continue indefinitely
-    write_csr(0x3c5, 0);
-    asm volatile("nop\n");
-    asm volatile("nop\n");
-    asm volatile("nop\n");
-}
-
-void snax_mac_sw_barrier() {
-    // poll csr 0x3c3 until HWPE MAC accelerator is finished
-    while (read_csr(0x3c3)) {
-    };
-    // This is necessary for the HWPE MAC accelerator to allow multiple runs
-    snax_mac_sw_clear();
-}
-
-void snax_mac_setup_simple_mult(uint32_t* a, uint32_t* b, uint32_t* o,
-                                uint32_t vector_length) {
-    /* Setup the hwpe_mac accelerator in simple_mult mode.
-     * This computes the product A*B in 32 bits and stores it starting
-     * from the pointer given by o
-     * args:
-     *  a: pointer in TCDM (L1) to vector A
-     *  b: pointer in TCDM (L1) to vector B
-     *  o: pointer in TCDM (L1) to where output O must be stored
-     *  vector_length: length of A,B and O
-     * */
-
-    // Set addresses
-    write_csr(0x3d0, (uint32_t)a);
-    write_csr(0x3d1, (uint32_t)b);
-    write_csr(0x3d3, (uint32_t)o);
-
-    // Set configs
-    write_csr(0x3d4, 1);                 // Number of iterations
-    write_csr(0x3d5, vector_length);     // Vector length
-    write_csr(0x3d6, simple_mult_mode);  // Set simple multiplication
-}
-
-void cpu_simple_mult(uint32_t* a, uint32_t* b, uint32_t* o,
-                     uint32_t vector_length) {
-    for (uint32_t i = 0; i < vector_length; i++) {
-        o[i] = a[i] * b[i];
-    };
-}
-
-int check_simple_mult(uint32_t* output, uint32_t* output_golden,
-                      uint32_t vector_length) {
-    /*
-     * Compare output to output_golden with length vector_length
-     */
-    uint32_t err = 0;
-    for (uint32_t i = 0; i < vector_length; i++) {
-        // Check if output is same as golden output
-        if (output[i] != output_golden[i]) {
-            err++;
-        };
-    };
-    return err;
-}
 
 int main() {
     uint32_t *local_a, *local_b;

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
@@ -5,6 +5,7 @@
 // Josse Van Delm <jvandelm@esat.kuleuven.be>
 // Ryan Antonio <rgantonio@esat.kuleuven.be>
 
+#include <stdint.h>
 #include "data.h"
 #include "mac.h"
 #include "snrt.h"

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
@@ -75,10 +75,11 @@ int main() {
     // Perform correctness check
     int err = 0;
     if (snrt_is_compute_core()) {
-        err = check_simple_mult(local_o, OUT, VEC_LEN);
-        // Compute using CPU multiplier and check
+        // Also perform calculation on CPU
         uint32_t cpu_output[VEC_LEN];
         cpu_simple_mult(local_a, local_b, cpu_output, VEC_LEN);
+        // Compare SNAX result with golden model
+        err = check_simple_mult(local_o, OUT, VEC_LEN);
         // Compare CPU result with golden model
         err += check_simple_mult(cpu_output, OUT, VEC_LEN);
     };

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/tiled/src/tiled.c
@@ -5,9 +5,9 @@
 // Josse Van Delm <jvandelm@esat.kuleuven.be>
 // Ryan Antonio <rgantonio@esat.kuleuven.be>
 
-#include "snrt.h"
-#include "mac.h"
 #include "data.h"
+#include "mac.h"
+#include "snrt.h"
 
 int main() {
     uint32_t *local_a, *local_b;

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
@@ -36,6 +36,8 @@ int main() {
     // Wait until computation is done
     snrt_cluster_hw_barrier();
 
+    // Technically we can already check the output here, but we still perform
+    // the transfer to L3 to match the tiled example's flow.
     // Use data mover to send output from TCDM to L3
     if (snrt_is_dm_core()) {
         size_t vector_size = VEC_LEN * sizeof(uint32_t);
@@ -54,10 +56,11 @@ int main() {
     // Perform correctness check
     int err = 0;
     if (snrt_is_compute_core()) {
-        err = check_simple_mult(local_o, OUT, VEC_LEN);
-        // Compute using CPU multiplier and check
+        // Also perform calculation on CPU
         uint32_t cpu_output[VEC_LEN];
         cpu_simple_mult(local_a, local_b, cpu_output, VEC_LEN);
+        // Compare SNAX result with golden model
+        err = check_simple_mult(local_o, OUT, VEC_LEN);
         // Compare CPU result with golden model
         err += check_simple_mult(cpu_output, OUT, VEC_LEN);
     };

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "snrt.h"
-
+#include "mac.h"
 #include "data.h"
 
 int main() {
@@ -48,21 +48,12 @@ int main() {
         write_csr(0x3d5, VEC_LEN);  // Vector length
         write_csr(0x3d6, 1);        // Set simple multiplication
 
-        // Write start CSR to launch accelerator
-        write_csr(0x3c0, 0);
+        snax_mac_launch();
 
         // Start of CSR start and poll until accelerator finishes
         uint32_t mac_start = snrt_mcycle();
 
-        uint32_t break_poll;
-
-        while (1) {
-            // 0x3c3 is the CSR address for accelerator status
-            break_poll = read_csr(0x3c3);
-            if (break_poll == 0) {
-                break;
-            };
-        };
+        snax_mac_sw_barrier();
 
         uint32_t mac_end = snrt_mcycle();
         uint32_t cpu_checker;

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
@@ -33,6 +33,9 @@ int main() {
         snax_mac_sw_barrier();
     }
 
+    // Wait until computation is done
+    snrt_cluster_hw_barrier();
+
     // Use data mover to send output from TCDM to L3
     if (snrt_is_dm_core()) {
         size_t vector_size = VEC_LEN * sizeof(uint32_t);

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "snrt.h"
-#include "mac.h"
 #include "data.h"
+#include "mac.h"
+#include "snrt.h"
 
 int main() {
     uint32_t *local_a, *local_b;

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include "data.h"
 #include "mac.h"
 #include "snrt.h"

--- a/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
+++ b/target/snitch_cluster/sw/apps/snax-mac-simple/untiled/src/untiled.c
@@ -29,16 +29,7 @@ int main() {
     snrt_cluster_hw_barrier();
 
     if (snrt_is_compute_core()) {
-        // Set addresses
-        write_csr(0x3d0, (uint32_t)local_a);
-        write_csr(0x3d1, (uint32_t)local_b);
-        write_csr(0x3d3, (uint32_t)local_o);
-
-        // Set configs
-        write_csr(0x3d4, 1);        // Number of iterations
-        write_csr(0x3d5, VEC_LEN);  // Vector length
-        write_csr(0x3d6, 1);        // Set simple multiplication
-
+        snax_mac_setup_simple_mult(local_a, local_b, local_o, VEC_LEN);
         snax_mac_launch();
         // Poll until accelerator finishes
         snax_mac_sw_barrier();

--- a/target/snitch_cluster/sw/snax/mac/Makefile
+++ b/target/snitch_cluster/sw/snax/mac/Makefile
@@ -1,0 +1,65 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+# Usage of absolute paths is required to externally include
+# this Makefile from multiple different locations
+
+MK_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+include $(MK_DIR)/../../toolchain.mk
+
+################
+## Directories #
+################
+
+# Fixed paths in repository tree
+ROOT     = $(abspath $(MK_DIR)/../../../../..)
+SNRT_DIR = $(ROOT)/sw/snRuntime
+## Paths relative to the runtime including this Makefile
+BUILDDIR = $(abspath build)
+SRC_DIR  = $(abspath src)
+
+####################
+## Build variables #
+####################
+
+INCDIRS += $(abspath include)
+INCDIRS += $(SNRT_DIR)/src
+INCDIRS += $(SNRT_DIR)/api
+INCDIRS += $(SNRT_DIR)/src/omp
+INCDIRS += $(SNRT_DIR)/api/omp
+INCDIRS += $(SNRT_DIR)/vendor/riscv-opcodes
+INCDIRS += $(ROOT)/target/snitch_cluster/sw/runtime/common
+INCDIRS += $(ROOT)/target/snitch_cluster/sw/runtime/rtl/src
+INCDIRS += $(ROOT)/target/snitch_cluster/sw/runtime/rtl/include
+
+############
+## Outputs #
+############
+
+OBJS        = $(BUILDDIR)/mac.o
+ALL_OUTPUTS = $(OBJS)
+
+
+##########
+## Rules #
+##########
+
+.PHONY: all
+all: $(ALL_OUTPUTS)
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)
+
+$(BUILDDIR):
+	mkdir -p $@
+
+$(BUILDDIR)/%.o: $(SRC_DIR)/%.c | $(BUILDDIR)
+	$(RISCV_CC) $(RISCV_CFLAGS) -c $< -o $@
+
+#ifneq ($(MAKECMDGOALS),clean)
+#-include $(DEPS)
+#endif

--- a/target/snitch_cluster/sw/snax/mac/include/mac.h
+++ b/target/snitch_cluster/sw/snax/mac/include/mac.h
@@ -1,3 +1,7 @@
+// Copyright 2023 KU Leuven.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 // * mac_mode = 0
 //   performs multiply-accumulate over elements to perform dot product

--- a/target/snitch_cluster/sw/snax/mac/include/mac.h
+++ b/target/snitch_cluster/sw/snax/mac/include/mac.h
@@ -1,0 +1,21 @@
+#pragma once
+// * mac_mode = 0
+//   performs multiply-accumulate over elements to perform dot product
+// * simple_mult_mode = 1
+//   performs simple elementwise multiplication
+enum mode { mac_mode, simple_mult_mode };
+
+void snax_mac_launch();
+
+void snax_mac_sw_clear();
+
+void snax_mac_sw_barrier();
+
+void snax_mac_setup_simple_mult(uint32_t* a, uint32_t* b, uint32_t* o,
+                                uint32_t vector_length);
+
+void cpu_simple_mult(uint32_t* a, uint32_t* b, uint32_t* o,
+                     uint32_t vector_length);
+
+int check_simple_mult(uint32_t* output, uint32_t* output_golden,
+                      uint32_t vector_length);

--- a/target/snitch_cluster/sw/snax/mac/include/mac.h
+++ b/target/snitch_cluster/sw/snax/mac/include/mac.h
@@ -1,6 +1,10 @@
 // Copyright 2023 KU Leuven.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Josse Van Delm <jvandelm@esat.kuleuven.be>
+
+#include <stdint.h>
 
 #pragma once
 // * mac_mode = 0

--- a/target/snitch_cluster/sw/snax/mac/src/mac.c
+++ b/target/snitch_cluster/sw/snax/mac/src/mac.c
@@ -4,8 +4,8 @@
 //
 // Josse Van Delm <jvandelm@esat.kuleuven.be>
 
-#include <stdint.h>
 #include "mac.h"
+#include <stdint.h>
 #include "snrt.h"
 
 void snax_mac_launch() {

--- a/target/snitch_cluster/sw/snax/mac/src/mac.c
+++ b/target/snitch_cluster/sw/snax/mac/src/mac.c
@@ -1,0 +1,70 @@
+#include "snrt.h"
+#include "mac.h"
+
+void snax_mac_launch() {
+    // Write start CSR to launch accelerator
+    write_csr(0x3c0, 0);
+}
+
+void snax_mac_sw_clear() {
+    // write 0x3c5 to clear HWPE accelerator
+    // Otherwise the accelerator goes into undefined behaviour:
+    // It might stall/continue indefinitely
+    write_csr(0x3c5, 0);
+    asm volatile("nop\n");
+    asm volatile("nop\n");
+    asm volatile("nop\n");
+}
+
+void snax_mac_sw_barrier() {
+    // poll csr 0x3c3 until HWPE MAC accelerator is finished
+    while (read_csr(0x3c3)) {
+    };
+    // This is necessary for the HWPE MAC accelerator to allow multiple runs
+    snax_mac_sw_clear();
+}
+
+void snax_mac_setup_simple_mult(uint32_t* a, uint32_t* b, uint32_t* o,
+                                uint32_t vector_length) {
+    /* Setup the hwpe_mac accelerator in simple_mult mode.
+     * This computes the product A*B in 32 bits and stores it starting
+     * from the pointer given by o
+     * args:
+     *  a: pointer in TCDM (L1) to vector A
+     *  b: pointer in TCDM (L1) to vector B
+     *  o: pointer in TCDM (L1) to where output O must be stored
+     *  vector_length: length of A,B and O
+     * */
+
+    // Set addresses
+    write_csr(0x3d0, (uint32_t)a);
+    write_csr(0x3d1, (uint32_t)b);
+    write_csr(0x3d3, (uint32_t)o);
+
+    // Set configs
+    write_csr(0x3d4, 1);                 // Number of iterations
+    write_csr(0x3d5, vector_length);     // Vector length
+    write_csr(0x3d6, simple_mult_mode);  // Set simple multiplication
+}
+
+void cpu_simple_mult(uint32_t* a, uint32_t* b, uint32_t* o,
+                     uint32_t vector_length) {
+    for (uint32_t i = 0; i < vector_length; i++) {
+        o[i] = a[i] * b[i];
+    };
+}
+
+int check_simple_mult(uint32_t* output, uint32_t* output_golden,
+                      uint32_t vector_length) {
+    /*
+     * Compare output to output_golden with length vector_length
+     */
+    uint32_t err = 0;
+    for (uint32_t i = 0; i < vector_length; i++) {
+        // Check if output is same as golden output
+        if (output[i] != output_golden[i]) {
+            err++;
+        };
+    };
+    return err;
+}

--- a/target/snitch_cluster/sw/snax/mac/src/mac.c
+++ b/target/snitch_cluster/sw/snax/mac/src/mac.c
@@ -1,7 +1,10 @@
 // Copyright 2023 KU Leuven.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Josse Van Delm <jvandelm@esat.kuleuven.be>
 
+#include <stdint.h>
 #include "mac.h"
 #include "snrt.h"
 

--- a/target/snitch_cluster/sw/snax/mac/src/mac.c
+++ b/target/snitch_cluster/sw/snax/mac/src/mac.c
@@ -1,5 +1,9 @@
-#include "snrt.h"
+// Copyright 2023 KU Leuven.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "mac.h"
+#include "snrt.h"
 
 void snax_mac_launch() {
     // Write start CSR to launch accelerator


### PR DESCRIPTION
This PR is to precede #38.
It makes both the untiled and tiled example look the same, such that they can more easily be compared by #38 .

This PR refactors some used routines/functions out of the examples, and adds them to an external library `mac.o`
This means that now you have to include `mac.h` and link against a built version of `mac.o`.

I think we can expect some performance degradations in this case w.r.t. inlining or not inlining certain functions, but I consider these things currently not super important.

@xiaoling-yi  and @rgantonio once I've properly finished this PR i think this can be interesting for you guys to have a look at, since future accelerators should define a similar interface when it comes to programming in my opinion.