### PR TITLE
Adding initial documentation for SNAX compilation and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository hosts the hardware and software for the Snitch cluster and its g
 
 ## Getting Started
 
-To get started, check out the [getting started guide](https://pulp-platform.github.io/snitch_cluster/ug/getting_started.html).
+To get started, check out the [getting started guide](https://kuleuven-micas.github.io/snitch_cluster/ug/getting_started.html).
 
 ## Content
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,11 @@
-# Snitch
+# SNitch Acceleration eXtension (SNAX)
+SNitch Acceleration eXtension (SNAX) is a platform that provides the basic needs of an accelerator in a multi-core system.
 
-The Snitch project is an open-source RISC-V hardware research project of ETH Zurich and University of Bologna targeting highest possible energy-efficiency. The system is designed around a versatile and small integer core, which we call Snitch. The system is ought to be highly parameterizable and suitable for many use-cases, ranging from small, control-only cores, to large many-core system made for pure number crunching in the HPC domain.
+* Users can control their accelerator with RISCV control status register (CSR) instructions.
+* These accelerators can access a direct memory with high flexibility and bandwidth through the tightly-coupled data memory (TCDM).
+* The platform is a complete hw-sw test environment where users can also profile the performance immediately.
+
+SNAX is extension of the [Snitch cluster](https://pulp-platform.github.io/snitch_cluster/) made by [PULP platform](https://pulp-platform.org/). Visit the links for more information.
 
 ## Getting Started
 
@@ -8,12 +13,15 @@ See our dedicated [getting started guide](ug/getting_started.md).
 
 ## Documentation
 
-The documentation is built from the latest master and hosted at github pages: [https://pulp-platform.github.io/snitch_cluster](https://pulp-platform.github.io/snitch_cluster).
+The documentation is built from the latest master and hosted at github pages: [https://github.com/KULeuven-MICAS/snitch_cluster](https://github.com/KULeuven-MICAS/snitch_cluster).
 
 ## About this Repository
 
-The original repository [https://github.com/pulp-platform/snitch](https://github.com/pulp-platform/snitch) was developed as a monorepo where external dependencies are "vendored-in" and checked in. For easier integration into heterogeneous systems with other PULP Platform IPs, the original repo was archived. This new repository [https://github.com/pulp-platform/snitch_cluster](https://github.com/pulp-platform/snitch_cluster) handles depenencies with [Bender](https://github.com/pulp-platform/bender) and has a couple of repositories as submodules.
-The Occamy System part of the original repository is being moved to its own repository [https://github.com/pulp-platform/occamy](https://github.com/pulp-platform/occamy).
+This SNAX repository consists of several IPs from the original Snitch cluster:
+
+* The original repository [https://github.com/pulp-platform/snitch](https://github.com/pulp-platform/snitch) was developed as a monorepo where external dependencies are "vendored-in" and checked in. For easier integration into heterogeneous systems with other PULP Platform IPs, the original repo was archived.
+* The Snitch cluster repository [https://github.com/pulp-platform/snitch_cluster](https://github.com/pulp-platform/snitch_cluster) handles depenencies with [Bender](https://github.com/pulp-platform/bender) and has a couple of repositories as submodules.
+* The Occamy System part of the original repository is being moved to its own repository [https://github.com/pulp-platform/occamy](https://github.com/pulp-platform/occamy). 
 
 
 ## Licensing

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,23 @@
+# Snitch Cluster
+The Snitch project is an open-source RISC-V hardware research project of ETH Zurich and University of Bologna targeting highest possible energy-efficiency. The system is designed around a versatile and small integer core, which we call Snitch. The system is ought to be highly parameterizable and suitable for many use-cases, ranging from small, control-only cores, to large many-core system made for pure number crunching in the HPC domain. The figure below shows a simplified overview of the Snitch cluster.
+
+![Snitch Cluster](https://drive.google.com/uc?id=1SGog8sbGcCkSuyD_X2uLteuqpqYAhJKS)
+
+!!! note "This is the SNAX repo"
+
+    You are looking at the KULeuven fork of Snitch Cluster developed by the PULP group. This fork, called SNAX, provides extra infrastructure for quickly adding tightly coupled  accelerators to a systems on a Snitch Cluster Level.
+
 # SNitch Acceleration eXtension (SNAX)
-SNitch Acceleration eXtension (SNAX) is a platform that provides the basic needs of an accelerator in a multi-core system.
+SNitch Acceleration eXtension (SNAX) is an extension of the Snitch platform that provides the basic needs of an accelerator in a multi-core system. SNAX allows multi-core accelerators at the cluster level.
 
 * Users can control their accelerator with RISCV control status register (CSR) instructions.
 * These accelerators can access a direct memory with high flexibility and bandwidth through the tightly-coupled data memory (TCDM).
 * The platform is a complete hw-sw test environment where users can also profile the performance immediately.
 
-SNAX is extension of the [Snitch cluster](https://pulp-platform.github.io/snitch_cluster/) made by [PULP platform](https://pulp-platform.org/). Visit the links for more information.
+The figure below shows a simplified overview of the SNAX cluster. 
+
+![SNAX Cluster](https://drive.google.com/uc?id=1PqMhcxbqWnJdn-EawCfGetc0CbqfFCK_)
+
 
 ## Getting Started
 
@@ -17,8 +29,7 @@ The documentation is built from the latest master and hosted at github pages: [h
 
 ## About this Repository
 
-This SNAX repository consists of several IPs from the original Snitch cluster:
-
+* This SNAX repository is maintained by KULeuven but it consists of several IPs originating from the PULP Snitch cluster.
 * The original repository [https://github.com/pulp-platform/snitch](https://github.com/pulp-platform/snitch) was developed as a monorepo where external dependencies are "vendored-in" and checked in. For easier integration into heterogeneous systems with other PULP Platform IPs, the original repo was archived.
 * The Snitch cluster repository [https://github.com/pulp-platform/snitch_cluster](https://github.com/pulp-platform/snitch_cluster) handles depenencies with [Bender](https://github.com/pulp-platform/bender) and has a couple of repositories as submodules.
 * The Occamy System part of the original repository is being moved to its own repository [https://github.com/pulp-platform/occamy](https://github.com/pulp-platform/occamy). 

--- a/docs/ug/getting_started.md
+++ b/docs/ug/getting_started.md
@@ -4,7 +4,7 @@
 
 Clone the repository:
 ```shell
-git clone https://github.com/pulp-platform/snitch_cluster.git --recurse-submodules
+git clone https://github.com/KULeuven-MICAS/snitch_cluster.git --recurse-submodules
 ```
 
 If you had already cloned the repository without the `--recurse-submodules` flag, clone its submodules:

--- a/docs/ug/tutorial.md
+++ b/docs/ug/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial
 
-The following tutorial will guide you through the use of the SNAX cluster. You will learn how to develop, simulate, debug and benchmark software for the SNAX cluster architecture.
+The following tutorial will guide you through the use of the Snitch/SNAX cluster. You will learn how to develop, simulate, debug and benchmark software for the Snitch/SNAX cluster architecture.
 
 ## Quick Start
 <!---

--- a/docs/ug/tutorial.md
+++ b/docs/ug/tutorial.md
@@ -1,14 +1,15 @@
 # Tutorial
 
-The following tutorial will guide you through the use of the Snitch cluster. You will learn how to develop, simulate, debug and benchmark software for the Snitch cluster architecture.
+The following tutorial will guide you through the use of the SNAX cluster. You will learn how to develop, simulate, debug and benchmark software for the SNAX cluster architecture.
 
+## Quick Start
 <!---
 The following documentation is directly included from `../../target/snitch_cluster/README.md`
 -->
 {%
    include-markdown '../../target/snitch_cluster/README.md'
    comments=false
-   start="## Tutorial"
+   start="## Quick Start"
 %}
 
 ## Using Verilator with LLVM

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,15 +1,15 @@
 # Copyright 2020 ETH Zurich and University of Bologna.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-site_name: Snitch Cluster
+site_name: SNAX Cluster
 theme:
   name: material
 
   icon:
     repo: fontawesome/brands/github
 
-repo_url: https://github.com/pulp-platform/snitch_cluster
-repo_name: pulp-platform/snitch_cluster
+repo_url: https://github.com/KULeuven-MICAS/snitch_cluster/
+repo_name: KULeuven-MICAS/snitch_cluster
 
 markdown_extensions:
   - admonition

--- a/target/snitch_cluster/README.md
+++ b/target/snitch_cluster/README.md
@@ -1,8 +1,8 @@
-# SNAX Cluster Target
+# Snitch/SNAX Cluster Target
 
 ## Details
 The Snitch cluster target (`target/snitch_cluster`) is a simple RTL testbench
-around a SNAX cluster. It is still the same as the Snitch cluster but with SNAX modifications. The cluster can be configured using a config file. By default, the config file which will be picked up is `target/snitch_cluster/cfg/default.hsjon`.
+around a SNAX cluster. It is still the same as the Snitch cluster but with SNAX modifications. The cluster can be configured using a config file. By default, the config file which will be picked up is `target/snitch_cluster/cfg/default.hjson`.
 
 The configuration parameters are documented using JSON schema. Documentation for the schema and available configuration options can be found in `docs/schema-doc/snitch_cluster/`).
 
@@ -11,7 +11,7 @@ preloaded using RISC-V's Front-End Server (`fesvr`).
 
 ## Quick Start
 
-These steps demonstrate how you quickly run a simple accelerator in SNAX shell. This assumes you either have the necessary dependencies already or have the docker started (see [getting started](ug/getting_started.md)).
+These quick start steps demonstrate how you quickly run a simple MAC-engine accelerator in SNAX shell. This assumes you either have the necessary dependencies already or have the docker started (see [getting started](ug/getting_started.md)). Use this if you want to try out a simple test quickly. More details for each step are in the [Detailed Tutorial](#detailed-tutorial) section.
 
 1. Move into `./target/snitch_cluster/.`
 
@@ -37,7 +37,7 @@ make DEBUG=ON sw
 bin/snitch_cluster.vlt sw/apps/snax-mac/build/snax-mac.elf
 ```
 
-5. Make traces. See (TODO add section) section. This produces a `.txt` dump which are the traces you can inspect.
+5. Make traces. See [Debugging and Benchmarking](#debugging-and-benchmarking) section. This produces a `.txt` dump which are the traces you can inspect.
 
 ```shell
 make traces
@@ -79,7 +79,7 @@ Note that the Snitch cluster RTL sources are partly automatically generated from
 Under the `cfg` folder, different configurations are provided. The `cfg/default.hjson` configuration instantiates 8 compute cores + 1 DMA core in the cluster. If you need a specific configuration you can create your own configuration file.
 
 We have other architectures for different accelerators:
-* `cfg/snax-mac.hjson` - is a SNAX shell with the simple [HWPE MAC engine](https://github.com/pulp-platform/hwpe-mac-engine).
+* `cfg/snax-mac.hjson` - is a SNAX shell with the simple [HWPE MAC engine](https://github.com/KULeuven-MICAS/hwpe-mac-engine).
 * `cfg/snax-mac.hjson` - is a SNAX shell with a [GEMM engine](https://github.com/KULeuven-MICAS/snax-gemm).
 
 The command `make bin/snitch_cluster.vlt` automatically generates the default (Snitch cluster with 8 ccompute ores and 1 DMA core) templated RTL sources. It implicitly used the default configuration file. To override the default configuration file, define the following variable when you invoke `make` to use the custom config files:
@@ -156,6 +156,10 @@ bin/snitch_cluster.vlt sw/apps/blas/axpy/build/axpy.elf --vcd
 # Display the vcd file in gtkwave
 gtkwave sim.vcd
 ```
+!!! note "SNAX does not support Banshee"
+
+    Careful! SNAX does not support Banshee hence do not use the simulator for SNAX builds.
+
 
 For Banshee, you need to give a specific cluster configuration to the simulator with the flag `--configuration <cluster_config.yaml>`. A default Snitch cluster configuration is given (`src/banshee.yaml`). The flag `--trace` enables the printing of the traces similar to the RTL simulation.
 For more information and debug options, please have a look at the Banshee repository: [https://github.com/pulp-platform/banshee](https://github.com/pulp-platform/banshee).
@@ -276,6 +280,13 @@ questa-2022.3 bin/snitch_cluster.vsim sw/apps/axpy/build/axpy.elf
 ### Debugging and benchmarking
 
 When you run the simulation, every core will log all the instructions it executes (along with additional information, such as the value of the registers before/after the instruction) in a trace file, located in the `target/snitch_cluster/logs` directory. The traces are identified by their hart ID, that is a unique ID for every hardware thread (hart) in a RISC-V system (and since all our cores have a single thread that is a unique ID per core)
+
+You need to install `spike-dasm` first. After making the hardware build, it should create a `work-vlt` directory. Do the following to install `spike-dasm`:
+
+1. Go to: `target/snitch_cluster/work-vlt/riscv-isa-sim`
+2. Do: `./configure --prefix="/opt/spike"`
+3. Do: `make install`
+4. Add to path `export PATH="/opt/spike/bin:$PATH"`
 
 The simulation logs the traces in a non-human readable format with `.dasm` extension. To convert these to a human-readable form run:
 

--- a/target/snitch_cluster/README.md
+++ b/target/snitch_cluster/README.md
@@ -1,24 +1,60 @@
-# Snitch cluster target
+# SNAX Cluster Target
 
+## Details
 The Snitch cluster target (`target/snitch_cluster`) is a simple RTL testbench
-around a Snitch cluster. The cluster can be configured using a config file. By default, the config file which will be picked up is `target/snitch_cluster/cfg/default.hsjon`.
+around a SNAX cluster. It is still the same as the Snitch cluster but with SNAX modifications. The cluster can be configured using a config file. By default, the config file which will be picked up is `target/snitch_cluster/cfg/default.hsjon`.
 
 The configuration parameters are documented using JSON schema. Documentation for the schema and available configuration options can be found in `docs/schema-doc/snitch_cluster/`).
 
 The cluster testbench simulates an infinite memory. The RISC-V ELF file to be simulated is
 preloaded using RISC-V's Front-End Server (`fesvr`).
 
-## Tutorial
+## Quick Start
+
+These steps demonstrate how you quickly run a simple accelerator in SNAX shell. This assumes you either have the necessary dependencies already or have the docker started (see [getting started](ug/getting_started.md)).
+
+1. Move into `./target/snitch_cluster/.`
+
+```shell
+cd ./target/snitch_cluster/.
+```
+
+2. Build custom hardware using one of the `cfg.hjson` files for a SNAX accelerator. The code below builds the SNAX with HWPE MAC engine. Add the `-j` option to set the number of  cores to run the build. The output is a RTL Verilator binary which runs the system. 
+
+```shell
+make CFG_OVERRIDE=cfg/snax-mac.hjson bin/snitch_cluster.vlt -j 16
+```
+
+3. Build the software. This produces `.elf` files (binary) which we feed into the built RTL builds.
+
+```shell
+make DEBUG=ON sw
+```
+
+4. Feed the `.elf` file into the RTL binary. Wait for the simulation to run. This produces `.dasm` (disassembly) files stored in the `./logs` directory.
+
+```shell
+bin/snitch_cluster.vlt sw/apps/snax-mac/build/snax-mac.elf
+```
+
+5. Make traces. See (TODO add section) section. This produces a `.txt` dump which are the traces you can inspect.
+
+```shell
+make traces
+```
+
+## Detailed Tutorial
 
 In the following tutorial you can assume the working directory to be `target/snitch_cluster`. All paths are to be assumed relative to this directory. Paths relative to the root of the repository are prefixed with a slash.
 
-### Building the hardware
+### Building the Hardware
 
-To compile the hardware for simulation run one of the following commands, depending on the desired simulator:
+To compile the default Snitch hardware for simulation run one of the following commands, depending on the desired simulator:
 
 ```shell
 # Verilator (for Docker users)
 make bin/snitch_cluster.vlt
+
 # Verilator (for IIS users)
 verilator-4.110 make bin/snitch_cluster.vlt
 
@@ -29,19 +65,25 @@ questa-2022.3 make bin/snitch_cluster.vsim
 vcs-2020.12 make bin/snitch_cluster.vcs
 ```
 
+You can find more details of the configuration file in the Cluster Configuration below.
+
 These commands compile the RTL sources respectively in `work-vlt`, `work-vsim` and `work-vcs`. Additionally, common C++ testbench sources (e.g. the [frontend server (fesvr)](https://github.com/riscv-software-src/riscv-isa-sim)) are compiled under `work`. Each command will also generate a script or an executable (e.g. `bin/snitch_cluster.vsim`) which you can invoke to simulate the hardware. We will see how to do this in a later section.
 
 ### Building the Banshee simulator
 Instead of running an RTL simulation, you can use our instruction-accurate simulator called `banshee`. To install the simulator, please follow the instructions of the Banshee repository: [https://github.com/pulp-platform/banshee](https://github.com/pulp-platform/banshee).
 
-### Cluster configuration
+### Cluster Configuration
 
 Note that the Snitch cluster RTL sources are partly automatically generated from a configuration file provided in `.hjson` format. Several RTL files are templated and use the `.hjson` configuration file to fill the template entries. An example is `/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl`.
 
 Under the `cfg` folder, different configurations are provided. The `cfg/default.hjson` configuration instantiates 8 compute cores + 1 DMA core in the cluster. If you need a specific configuration you can create your own configuration file.
 
-The command you executed previously automatically generated the templated RTL sources. It implicitly used the default configuration file.
-To override the default configuration file, define the following variable when you invoke `make`:
+We have other architectures for different accelerators:
+* `cfg/snax-mac.hjson` - is a SNAX shell with the simple [HWPE MAC engine](https://github.com/pulp-platform/hwpe-mac-engine).
+* `cfg/snax-mac.hjson` - is a SNAX shell with a [GEMM engine](https://github.com/KULeuven-MICAS/snax-gemm).
+
+The command `make bin/snitch_cluster.vlt` automatically generates the default (Snitch cluster with 8 ccompute ores and 1 DMA core) templated RTL sources. It implicitly used the default configuration file. To override the default configuration file, define the following variable when you invoke `make` to use the custom config files:
+
 ```shell
 make CFG_OVERRIDE=cfg/custom.hjson bin/snitch_cluster.vlt
 ```
@@ -62,13 +104,13 @@ make DEBUG=ON sw
 make SELECT_RUNTIME=banshee DEBUG=ON sw
 ```
 
-The `sw` target first generates some C header files which depend on the hardware configuration. Hence, the need to generate the software for the same configuration as your hardware. Afterwards, it recursively invokes the `make` target in the `sw` subdirectory to build the apps/kernels which have been developed in that directory.
+The `sw` target first generates some C header files which depend on the hardware configuration. Hence, the need to generate the software for the same configuration as your hardware. Afterwards, it recursively invokes the `make` target in the `sw` subdirectory to build the `apps/kernels` which have been developed in that directory.
 
 The `DEBUG=ON` flag is used to tell the compiler to produce debugging symbols. It is necessary for the `annotate` target, showcased in the Debugging section of this guide, to work.
 
 The `SELECT_RUNTIME` flag is set by default to `rtl`. To build the software with the Banshee runtime, set the flag to `banshee`.
 
-___Note:__ the RTL is not the only source which is generated from the configuration file. The software stack also depends on the configuration file. Make sure you always build the software with the same configuration of the hardware you are going to run it on._
+___Note:__ the RTL is not the only source which is generated from the configuration file. The software stack also depends on the configuration file. **Make sure you always build the software with the same configuration of the hardware you are going to run it on**._
 
 ### Running a simulation
 
@@ -84,6 +126,7 @@ Run one of the executables which was compiled in the previous step on your Snitc
 ```shell
 # Verilator (for Docker users)
 bin/snitch_cluster.vlt sw/apps/blas/axpy/build/axpy.elf
+
 # Verilator (for IIS users)
 verilator-4.110 bin/snitch_cluster.vlt sw/apps/blas/axpy/build/axpy.elf
 
@@ -102,6 +145,16 @@ The previous commands will run the simulation in your current terminal. You can 
 ```shell
 # Questa (for IIS users)
 questa-2022.3 bin/snitch_cluster.vsim.gui sw/apps/blas/axpy/build/axpy.elf
+```
+
+You can also produce a `vcd` file which you can display on [gtkwave](https://gtkwave.sourceforge.net/).
+
+```shell
+# Add the --vcd at the end to generate vcd files. This produces sim.vcd
+bin/snitch_cluster.vlt sw/apps/blas/axpy/build/axpy.elf --vcd
+
+# Display the vcd file in gtkwave
+gtkwave sim.vcd
 ```
 
 For Banshee, you need to give a specific cluster configuration to the simulator with the flag `--configuration <cluster_config.yaml>`. A default Snitch cluster configuration is given (`src/banshee.yaml`). The flag `--trace` enables the printing of the traces similar to the RTL simulation.
@@ -234,6 +287,7 @@ In addition to generating readable traces (`.txt` format), the above command als
 
 ```bash
 make logs/perf.csv
+
 # View the CSV file
 libreoffice logs/perf.csv
 ```

--- a/target/snitch_cluster/README.md
+++ b/target/snitch_cluster/README.md
@@ -65,7 +65,9 @@ questa-2022.3 make bin/snitch_cluster.vsim
 vcs-2020.12 make bin/snitch_cluster.vcs
 ```
 
-You can find more details of the configuration file in the Cluster Configuration below.
+!!! note
+
+    You can find more details of the configuration file in the Cluster Configuration below.
 
 These commands compile the RTL sources respectively in `work-vlt`, `work-vsim` and `work-vcs`. Additionally, common C++ testbench sources (e.g. the [frontend server (fesvr)](https://github.com/riscv-software-src/riscv-isa-sim)) are compiled under `work`. Each command will also generate a script or an executable (e.g. `bin/snitch_cluster.vsim`) which you can invoke to simulate the hardware. We will see how to do this in a later section.
 
@@ -80,9 +82,9 @@ Under the `cfg` folder, different configurations are provided. The `cfg/default.
 
 We have other architectures for different accelerators:
 * `cfg/snax-mac.hjson` - is a SNAX shell with the simple [HWPE MAC engine](https://github.com/KULeuven-MICAS/hwpe-mac-engine).
-* `cfg/snax-mac.hjson` - is a SNAX shell with a [GEMM engine](https://github.com/KULeuven-MICAS/snax-gemm).
+* `cfg/snax-gemm.hjson` - is a SNAX shell with a [GEMM engine](https://github.com/KULeuven-MICAS/snax-gemm).
 
-The command `make bin/snitch_cluster.vlt` automatically generates the default (Snitch cluster with 8 ccompute ores and 1 DMA core) templated RTL sources. It implicitly used the default configuration file. To override the default configuration file, define the following variable when you invoke `make` to use the custom config files:
+The command `make bin/snitch_cluster.vlt` automatically generates the default (Snitch cluster with 8 compute ores and 1 DMA core) templated RTL sources. It implicitly used the default configuration file (`cfg/default.hjson`). To override the default configuration file, define the following variable when you invoke `make` to use the custom config files:
 
 ```shell
 make CFG_OVERRIDE=cfg/custom.hjson bin/snitch_cluster.vlt
@@ -110,7 +112,9 @@ The `DEBUG=ON` flag is used to tell the compiler to produce debugging symbols. I
 
 The `SELECT_RUNTIME` flag is set by default to `rtl`. To build the software with the Banshee runtime, set the flag to `banshee`.
 
-___Note:__ the RTL is not the only source which is generated from the configuration file. The software stack also depends on the configuration file. **Make sure you always build the software with the same configuration of the hardware you are going to run it on**._
+!!! note
+
+    the RTL is not the only source which is generated from the configuration file. The software stack also depends on the configuration file. **Make sure you always build the software with the same configuration of the hardware you are going to run it on**
 
 ### Running a simulation
 
@@ -281,11 +285,11 @@ questa-2022.3 bin/snitch_cluster.vsim sw/apps/axpy/build/axpy.elf
 
 When you run the simulation, every core will log all the instructions it executes (along with additional information, such as the value of the registers before/after the instruction) in a trace file, located in the `target/snitch_cluster/logs` directory. The traces are identified by their hart ID, that is a unique ID for every hardware thread (hart) in a RISC-V system (and since all our cores have a single thread that is a unique ID per core)
 
-You need to install `spike-dasm` first. After making the hardware build, it should create a `work-vlt` directory. Do the following to install `spike-dasm`:
+You need to build and install `spike-dasm` from source first. After making the hardware build, it should create a `work-vlt` directory. Do the following to install `spike-dasm`:
 
 1. Go to: `target/snitch_cluster/work-vlt/riscv-isa-sim`
-2. Do: `./configure --prefix="/opt/spike"`
-3. Do: `make install`
+2. `spike-dasm` uses GNU autoconf for makefile generation: `./configure --prefix="/opt/spike"`
+3. Build and install `spike-dasm` with: `make -j$(nproc) install`
 4. Add to path `export PATH="/opt/spike/bin:$PATH"`
 
 The simulation logs the traces in a non-human readable format with `.dasm` extension. To convert these to a human-readable form run:


### PR DESCRIPTION
This PR is an initial update of the documentation. It adds the following:

- Link changes to point to the MICAS KULeuven links.
- A quick start list of instructions for running the software.
- More details on other sections that need more information.

Since this is documentation, it would be great if we could update this PR together where we see fit.

Please let me know if it's also a good time to add the HW documentation in this PR or a separate PR.

If you want to checkout what it looks like in the webpages:

1. Go inside the docker container
2. At `/repo` directory do `mkdocs serve` this will launch a server.
3. Checkout `http://127.0.0.1:8000` in a local web browser. 

Have fun!