### PR TITLE
Update README and CI to use image uploaded in ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Simulate SW on Snitch Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: rgantonio/snax-chisel-test
+      image: ghcr.io/kuleuven-micas/snax:latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -50,7 +50,7 @@ jobs:
     name: Simulate SW on SNAX MAC Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: rgantonio/snax-chisel-test
+      image: ghcr.io/kuleuven-micas/snax:latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -72,7 +72,7 @@ jobs:
     name: Simulate SW on SNAX GEMM Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: rgantonio/snax-chisel-test
+      image: ghcr.io/kuleuven-micas/snax:latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/util/container/README.md
+++ b/util/container/README.md
@@ -10,7 +10,7 @@ There is a pre-built version of the container available online. This version is 
 
 To download the container, first login to the GitHub container registry:
 ```shell
-$ docker login ghcr.io
+$ docker login docker.io
 ```
 You will be asked for a username (your GitHub username).
 As a password you should use a
@@ -19,7 +19,7 @@ that at least has package registry read permission.
 
 You can then install the container by running:
 ```shell
-$ docker pull ghcr.io/pulp-platform/snitch_cluster:main
+$ docker pull docker.io/rgantonio/snax-chisel-test
 ```
 
 ### Build instructions
@@ -28,7 +28,7 @@ In case you cannot use the pre-built container, e.g. if you need to make changes
 container locally by running the following command in the root of the repository:
 
 ```shell
-$ sudo docker build -t ghcr.io/pulp-platform/snitch_cluster:main -f util/container/Dockerfile .
+$ sudo docker build -t docker.io/rgantonio/snax-chisel-test -f util/container/DockerfileChisel .
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ $ sudo docker build -t ghcr.io/pulp-platform/snitch_cluster:main -f util/contain
 To run the container in interactive mode:
 
 ```shell
-$ docker run -it -v $REPO_TOP:/repo -w /repo ghcr.io/pulp-platform/snitch_cluster:main
+$ docker run -it -v $REPO_TOP:/repo -w /repo docker.io/rgantonio/snax-chisel-test
 ```
 
 ## Limitations

--- a/util/container/README.md
+++ b/util/container/README.md
@@ -10,7 +10,7 @@ There is a pre-built version of the container available online. This version is 
 
 To download the container, first login to the GitHub container registry:
 ```shell
-$ docker login docker.io
+$ docker login ghcr.io
 ```
 You will be asked for a username (your GitHub username).
 As a password you should use a
@@ -19,7 +19,7 @@ that at least has package registry read permission.
 
 You can then install the container by running:
 ```shell
-$ docker pull docker.io/rgantonio/snax-chisel-test
+$ docker pull ghcr.io/kuleuven-micas/snax:latest
 ```
 
 ### Build instructions
@@ -28,7 +28,7 @@ In case you cannot use the pre-built container, e.g. if you need to make changes
 container locally by running the following command in the root of the repository:
 
 ```shell
-$ sudo docker build -t docker.io/rgantonio/snax-chisel-test -f util/container/DockerfileChisel .
+$ sudo docker build -t ghcr.io/kuleuven-micas/snax:latest -f util/container/DockerfileChisel .
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ $ sudo docker build -t docker.io/rgantonio/snax-chisel-test -f util/container/Do
 To run the container in interactive mode:
 
 ```shell
-$ docker run -it -v $REPO_TOP:/repo -w /repo docker.io/rgantonio/snax-chisel-test
+$ docker run -it -v $REPO_TOP:/repo -w /repo ghcr.io/kuleuven-micas/snax:latest
 ```
 
 ## Limitations


### PR DESCRIPTION
This PR changes the docker container to be used:

1. Update instructions to use the uploaded container ghcr.io/kuleuven-micas/snax:latest
2. Update the CI to use the container ghcr.io/kuleuven-micas/snax:latest

Overall should be a nice upgrade 😄 