### PR TITLE
sw: Add upstream LLVM/Clang installation in docker

### DIFF
--- a/util/container/DockerfileChisel
+++ b/util/container/DockerfileChisel
@@ -24,4 +24,7 @@ RUN apt-get install -y sbt
 RUN wget https://github.com/llvm/circt/releases/download/firtool-1.42.0/firrtl-bin-ubuntu-20.04.tar.gz && \
     tar -xvzf firrtl-bin-ubuntu-20.04.tar.gz
 
+# Install generic LLVM toolchain in /usr/bin - latest stable release is 17
+RUN  wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh
+
 ENV PATH "/tools/firtool-1.42.0/bin/:${PATH}"


### PR DESCRIPTION
This adds a newer version of LLVM/Clang to the container with a an apt script provided by the LLVM project.
The installed version is 17 (latest stable).
Note that the name does not clash with the other installed version (in `/tools/riscv-llvm`).
This version is installed in `/usr/bin` and is postfixed with the version number, so `/usr/bin/clang-17`

Pulled out of #57 and necessary before pulling in #57