### PR TITLE
ci: Change workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@
 name: ci
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 jobs:
 
   ########

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@
 
 # Run functional regression checks
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 jobs:
 
   ########

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -6,9 +6,9 @@
 name: gitlab-ci
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
 jobs:
   gitlab-ci:

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -4,7 +4,12 @@
 
 # Some CI tests run on our GitLab servers due to licenses and tools
 name: gitlab-ci
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
 jobs:
   gitlab-ci:
     name: Internal Gitlab CI

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,9 @@
 name: lint
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,11 @@
 
 # Run all lint checks
 name: lint
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
 


### PR DESCRIPTION
This PR changes the CI workflow triggers for CI and Lint workflows such that they are not run twice every time a pull request is made.

Thanks to the excellent work of @jorendumoulin :heart: 