### PR TITLE
ci: Modify docker build CI

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,6 +27,6 @@ jobs:
           context: .
           file: util/container/DockerfileChisel
           push: true
-          tags: ghcr.io/kuleuven-micas/snax:${{ github.ref_name }}
+          tags: ghcr.io/kuleuven-micas/snax:latest
           build-args: |-
             SNITCH_LLVM_VERSION=latest

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,13 +20,13 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: util/container/Dockerfile
+          file: util/container/DockerfileChisel
           push: true
-          tags: ghcr.io/pulp-platform/snitch_cluster:${{ github.ref_name }}
+          tags: ghcr.io/kuleuven-micas/snax:${{ github.ref_name }}
           build-args: |-
             SNITCH_LLVM_VERSION=latest

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PAT }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
This PR modifies the CI of the docker build such that it builds the SNAX container rather than the original Snitch Cluster container.

The DockerfileChisel contains the updated Snitch Cluster container but also added to it is the Chisel environment as well as the new LLVM 17.