### PR TITLE
sw: Add support for multiple yaml files in run.py

### DIFF
--- a/util/sim/sim_utils.py
+++ b/util/sim/sim_utils.py
@@ -91,7 +91,11 @@ def get_simulations(testlists, simulator):
         for test in tests:
             test['elf'] = testlist_path.parent / test['elf']
             if 'cmd' in test:
-                test['cmd'] = [resolve_relative_path(testlist_path.parent, arg) for arg in test['cmd']]
+                resolved_paths = []
+                for arg in test['cmd']:
+                    resolved_path = resolve_relative_path(testlist_path.parent, arg)
+                    resolved_paths.append(resolved_path)
+                test['cmd'] = resolved_paths
         all_tests.extend(tests)
     # Create simulation object for every test which supports the specified simulator
     simulations = [simulator.get_simulation(test) for test in all_tests if simulator.supports(test)]

--- a/util/sim/sim_utils.py
+++ b/util/sim/sim_utils.py
@@ -21,7 +21,8 @@ def parser(default_simulator='vsim', simulator_choices=['vsim']):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'testlist',
-        help='File specifying a list of apps to run')
+        nargs="+",
+        help='File(s) specifying a list of apps to run')
     parser.add_argument(
         '--simulator',
         action='store',
@@ -79,18 +80,21 @@ def resolve_relative_path(base_path, s):
 
 
 # Create simulation objects from a test list file
-def get_simulations(testlist, simulator):
+def get_simulations(testlists, simulator):
     # Get tests from test list file
-    testlist_path = Path(testlist).absolute()
-    with open(testlist_path, 'r') as f:
-        tests = yaml.safe_load(f)['runs']
-    # Convert relative paths in testlist file to absolute paths
-    for test in tests:
-        test['elf'] = testlist_path.parent / test['elf']
-        if 'cmd' in test:
-            test['cmd'] = [resolve_relative_path(testlist_path.parent, arg) for arg in test['cmd']]
+    all_tests = []
+    for testlist in testlists:
+        testlist_path = Path(testlist).absolute()
+        with open(testlist_path, 'r') as f:
+            tests = yaml.safe_load(f)['runs']
+        # Convert relative paths in testlist file to absolute paths
+        for test in tests:
+            test['elf'] = testlist_path.parent / test['elf']
+            if 'cmd' in test:
+                test['cmd'] = [resolve_relative_path(testlist_path.parent, arg) for arg in test['cmd']]
+        all_tests.extend(tests)
     # Create simulation object for every test which supports the specified simulator
-    simulations = [simulator.get_simulation(test) for test in tests if simulator.supports(test)]
+    simulations = [simulator.get_simulation(test) for test in all_tests if simulator.supports(test)]
     return simulations
 
 


### PR DESCRIPTION
Small tweak which is useful for #57 , that splits run.yaml into multiple different yaml files.
I just made the argument a "one or more" and put a for loop around the test readout logic.