### PR TITLE
ci: Move sw builds before hw build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Build Software
+        run: |
+          make CFG_OVERRIDE=cfg/snax-mac.hjson -C target/snitch_cluster sw
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac.hjson \
           -C target/snitch_cluster bin/snitch_cluster.vlt
-      - name: Build Software
-        run: |
-          make -C target/snitch_cluster sw
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -90,15 +90,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Build Software
+        run: |
+          make -C target/snitch_cluster sw \
+          CFG_OVERRIDE=cfg/snax-mac.hjson \
+          SELECT_RUNTIME=rtl-generic \
+          SELECT_TOOLCHAIN=llvm-generic
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac.hjson \
           -C target/snitch_cluster bin/snitch_cluster.vlt
-      - name: Build Software
-        run: |
-          make -C target/snitch_cluster sw \
-          SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -114,13 +115,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Build Software
+        run: |
+          make CFG_OVERRIDE=cfg/snax-gemm.hjson -C target/snitch_cluster sw
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-gemm.hjson \
           -C target/snitch_cluster bin/snitch_cluster.vlt
-      - name: Build Software
-        run: |
-          make -C target/snitch_cluster sw
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-
@@ -137,15 +138,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - name: Build Hardware
-        run: |
-          make CFG_OVERRIDE=cfg/snax-gemm.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
           SELECT_RUNTIME=rtl-generic \
-          SELECT_TOOLCHAIN=llvm-generic
+          SELECT_TOOLCHAIN=llvm-generic \
+          CFG_OVERRIDE=cfg/snax-gemm.hjson
+      - name: Build Hardware
+        run: |
+          make CFG_OVERRIDE=cfg/snax-gemm.hjson \
+          -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster
         run: |-


### PR DESCRIPTION
Moves software builds before hardware builds.
Software builds are faster and will on average most likely trigger a fail in the pipeline earlier.

note: cherry picked off of #57 