### PR TITLE
Add base SNAX accelerator barrier

### DIFF
--- a/hw/snax_hwpe_mac/src/snax_mac_wrapper.sv
+++ b/hw/snax_hwpe_mac/src/snax_mac_wrapper.sv
@@ -15,17 +15,25 @@ module snax_mac_wrapper # (
   parameter type         tcdm_req_t        = logic,
   parameter type         tcdm_rsp_t        = logic
 )(
-  input     logic                               clk_i,
-  input     logic                               rst_ni,
-  input     logic                               snax_qvalid_i,
-  output    logic                               snax_qready_o,
-  input     acc_req_t                           snax_req_i,
-  output    acc_rsp_t                           snax_resp_o,
-  output    logic                               snax_pvalid_o,
-  input     logic                               snax_pready_i,
+  input     logic                           clk_i,
+  input     logic                           rst_ni,
+  input     logic                           snax_qvalid_i,
+  output    logic                           snax_qready_o,
+  input     acc_req_t                       snax_req_i,
+  output    acc_rsp_t                       snax_resp_o,
+  output    logic                           snax_pvalid_o,
+  input     logic                           snax_pready_i,
   output    tcdm_req_t  [SnaxTcdmPorts-1:0] snax_tcdm_req_o,
-  input     tcdm_rsp_t  [SnaxTcdmPorts-1:0] snax_tcdm_rsp_i
+  input     tcdm_rsp_t  [SnaxTcdmPorts-1:0] snax_tcdm_rsp_i,
+  output    logic                           snax_barrier_o
 );
+
+  //------------------------------
+  // Event control
+  //------------------------------
+  logic [1:0] evt;
+  assign snax_barrier_o = |evt;
+
   //------------------------------
   // HWPE control interface
   //------------------------------
@@ -93,7 +101,7 @@ module snax_mac_wrapper # (
     .clk_i          ( clk_i               ),
     .rst_ni         ( rst_ni              ),
     .test_mode_i    ( 1'b0                ),
-    .evt_o          (                     ),      // Unused
+    .evt_o          ( evt                 ),
     .tcdm_req       ( snax_mem.req        ),
     .tcdm_gnt       ( snax_mem.gnt        ),      // input
     .tcdm_add       ( snax_mem.add        ),

--- a/hw/snitch/src/csr_snax_def.sv
+++ b/hw/snitch/src/csr_snax_def.sv
@@ -2,5 +2,7 @@
 package csr_snax_def;
 localparam logic [11:0] CSR_SNAX_BEGIN = 12'h3c0;
 localparam logic [11:0] CSR_SNAX_END = 12'h5ff;
+localparam logic [11:0] SNAX_CSR_BARRIER_EN = 12'h7c3;
+localparam logic [11:0] SNAX_CSR_BARRIER = 12'h7c4;
 endpackage
 // verilog_lint: waive-stop parameter-name-style

--- a/hw/snitch_cluster/src/snitch_cc.sv
+++ b/hw/snitch_cluster/src/snitch_cc.sv
@@ -137,6 +137,7 @@ module snitch_cc #(
   output snitch_pkg::core_events_t   core_events_o,
   input  addr_t                      tcdm_addr_base_i,
   // Cluster HW barrier
+  input  logic                       snax_barrier_i,
   output logic                       barrier_o,
   input  logic                       barrier_i
 );
@@ -269,6 +270,7 @@ module snitch_cc #(
     .fpu_fmt_mode_o ( fpu_fmt_mode ),
     .fpu_status_i ( fpu_status ),
     .core_events_o ( snitch_events),
+    .snax_barrier_i (snax_barrier_i ),
     .barrier_o ( barrier_o ),
     .barrier_i ( barrier_i )
   );

--- a/hw/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/snitch_cluster/src/snitch_cluster.sv
@@ -233,6 +233,7 @@ module snitch_cluster
   output logic      [NrCores-1:0]            snax_pready_o,
   input  tcdm_req_t [TotalSnaxTcdmPorts-1:0] snax_tcdm_req_i,
   output tcdm_rsp_t [TotalSnaxTcdmPorts-1:0] snax_tcdm_rsp_o,
+  input  logic      [NrCores-1:0]            snax_barrier_i,
   /// AXI Core cluster in-port.
   input  narrow_in_req_t                narrow_in_req_i,
   output narrow_in_resp_t               narrow_in_resp_o,
@@ -928,6 +929,7 @@ module snitch_cluster
         .snax_pready_o (snax_pready_o[i]),
         .core_events_o (core_events[i]),
         .tcdm_addr_base_i (tcdm_start_address),
+        .snax_barrier_i (snax_barrier_i[i]),
         .barrier_o (barrier_in[i]),
         .barrier_i (barrier_out)
       );

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -306,6 +306,7 @@ module ${cfg['name']}_wrapper (
   ${cfg['pkg_name']}::acc_resp_t [${cfg['pkg_name']}::NrCores-1:0] snax_resp;
   logic      [${cfg['pkg_name']}::NrCores-1:0] snax_pvalid;
   logic      [${cfg['pkg_name']}::NrCores-1:0] snax_pready;
+  logic      [${cfg['pkg_name']}::NrCores-1:0] snax_barrier;
   ## This set of lines are for the internal pre-calculations for SNAX ports
   <%
     extract_port_num_list = []
@@ -441,6 +442,7 @@ module ${cfg['name']}_wrapper (
     .snax_pready_o (snax_pready),
     .snax_tcdm_req_i (snax_tcdm_req),
     .snax_tcdm_rsp_o (snax_tcdm_rsp),
+    .snax_barrier_i  (snax_barrier),
 % if cfg['sram_cfg_expose']:
     .sram_cfgs_i (sram_cfgs_i),
 % else:
@@ -477,6 +479,7 @@ module ${cfg['name']}_wrapper (
     .snax_resp_o ( snax_resp[${idx}] ),
     .snax_pvalid_o ( snax_pvalid[${idx}] ),
     .snax_pready_i ( snax_pready[${idx}] ),
+    .snax_barrier_o ( snax_barrier[${idx}] ),
     .snax_tcdm_req_o ( snax_tcdm_req[${offset_list[idx+1]-1}:${offset_list[idx]}] ),
     .snax_tcdm_rsp_i ( snax_tcdm_rsp[${offset_list[idx+1]-1}:${offset_list[idx]}] )
   );
@@ -485,6 +488,7 @@ module ${cfg['name']}_wrapper (
   assign snax_qready[${idx}] = '0;
   assign snax_resp[${idx}] = '0;
   assign snax_pvalid[${idx}] = '0;
+  assign snax_barrier[${idx}] = '0;
   
   % endif
 % endfor

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -461,7 +461,30 @@ module ${cfg['name']}_wrapper (
   // Accelerator instances if there are accelerator ports
   // If there are not accelerator ports, we tie the input signals to 0
 % for idx, c in enumerate(cfg['cores']):
-  % if c['snax_acc'] != "none":
+  % if c['snax_acc'] == "snax_gemm_wrapper":
+  ${c['snax_acc']} # (
+    .DataWidth ( ${cfg['pkg_name']}::NarrowDataWidth ),
+    .SnaxTcdmPorts ( SnaxTcdmPorts[${idx}] ),
+    .acc_req_t ( ${cfg['pkg_name']}::acc_req_t ),
+    .acc_rsp_t ( ${cfg['pkg_name']}::acc_resp_t ),
+    .tcdm_req_t ( ${cfg['pkg_name']}::tcdm_req_t ),
+    .tcdm_rsp_t ( ${cfg['pkg_name']}::tcdm_rsp_t )
+  ) i_${c['snax_acc']}_${idx}  (
+    .clk_i ( clk_i ),
+    .rst_ni ( rst_ni ),
+    .snax_req_i ( snax_req[${idx}] ),
+    .snax_qvalid_i ( snax_qvalid[${idx}] ),
+    .snax_qready_o ( snax_qready[${idx}] ),
+    .snax_resp_o ( snax_resp[${idx}] ),
+    .snax_pvalid_o ( snax_pvalid[${idx}] ),
+    .snax_pready_i ( snax_pready[${idx}] ),
+    .snax_tcdm_req_o ( snax_tcdm_req[${offset_list[idx+1]-1}:${offset_list[idx]}] ),
+    .snax_tcdm_rsp_i ( snax_tcdm_rsp[${offset_list[idx+1]-1}:${offset_list[idx]}] )
+  );
+
+  assign snax_barrier[${idx}] = '0;
+
+  % elif c['snax_acc'] != "none":
 
   ${c['snax_acc']} # (
     .DataWidth ( ${cfg['pkg_name']}::NarrowDataWidth ),
@@ -483,6 +506,7 @@ module ${cfg['name']}_wrapper (
     .snax_tcdm_req_o ( snax_tcdm_req[${offset_list[idx+1]-1}:${offset_list[idx]}] ),
     .snax_tcdm_rsp_i ( snax_tcdm_rsp[${offset_list[idx+1]-1}:${offset_list[idx]}] )
   );
+
   % else:
 
   assign snax_qready[${idx}] = '0;

--- a/target/snitch_cluster/sw/apps/snax-mac/src/snax-mac.c
+++ b/target/snitch_cluster/sw/apps/snax-mac/src/snax-mac.c
@@ -53,7 +53,7 @@ int main() {
         write_csr(0x3d5, 19);  // Vector length
 
         // Enable SNAX barrier
-        write_csr(0x7c3, 1); 
+        write_csr(0x7c3, 1);
 
         // Write start CSR to launch accelerator
         write_csr(0x3c0, 0);

--- a/target/snitch_cluster/sw/apps/snax-mac/src/snax-mac.c
+++ b/target/snitch_cluster/sw/apps/snax-mac/src/snax-mac.c
@@ -52,21 +52,17 @@ int main() {
         write_csr(0x3d4, 1);   // Number of iterations
         write_csr(0x3d5, 19);  // Vector length
 
+        // Enable SNAX barrier
+        write_csr(0x7c3, 1); 
+
         // Write start CSR to launch accelerator
         write_csr(0x3c0, 0);
 
         // Start of CSR start and poll until accelerator finishes
         uint32_t mac_start = snrt_mcycle();
 
-        uint32_t break_poll;
-
-        while (1) {
-            // 0x3c3 is the CSR address for accelerator status
-            break_poll = read_csr(0x3c3);
-            if (break_poll == 0) {
-                break;
-            };
-        };
+        // Trigger SNAX barrier
+        write_csr(0x7c4, 0);
 
         uint32_t mac_end = snrt_mcycle();
 


### PR DESCRIPTION
This PR simply adds the SNAX accelerator barrier.

Architecturally a simple barrier that stalls a Snich core whenever the barrier is called. It is required that an accelerator attaches a pulse signal that unlocks the barrier. The barrier is just a simple lock mechanism inside a Snitch core. Note that it assumes that the Snitch core controls a single accelerator only. A separate PR will be made for multiple accelerator attachments.

Here we only provide it for the HWPE MAC. We need @xiaoling-yi's help later to attach it to the GEMM. Although the GEMM runs very fast compared to the MAC anyway.

This PR includes modifications to:
* Snitch, Snitch core cluster, Snitch cluster
* Template wrapper
* SNAX MAC sw that uses the barrier

The barrier is controlled with 2 mechanisms, an enable signal and the actual barrier call. The enable signal is a write unto CSR address 0x7c3, while the barrier call is a read (or write, it doesn't matter) to CSR address 0x7c4.

This resolves the problem of polling an accelerator and hence can bring the system into a much more power (or energy) saving state.

Note that the barrier expects a pulse-done signal from the accelerator. Any wrapper can have this implemented. Either a pulse or a sticky done signal should be right also.