### PR TITLE
Fix template to use new SNAX GEMM signal barrier

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -29,7 +29,7 @@ dependencies:
   tech_cells_generic: { git: https://github.com/pulp-platform/tech_cells_generic, version:  0.2.11  }
   riscv-dbg:          { git: https://github.com/pulp-platform/riscv-dbg,          version:  0.8.0   }
   hwpe-mac-engine:    { git: https://github.com/KULeuven-MICAS/hwpe-mac-engine.git, rev: 5d3b4525b665169fc8321c8a811f3c83ad3c72e8 }
-  snax-gemm:          { git: https://github.com/KULeuven-MICAS/snax-gemm.git,     rev: 7e04484633da28513bdbe96a73a86a8476f69da4 }
+  snax-gemm:          { git: https://github.com/KULeuven-MICAS/snax-gemm.git,     rev: f4eaa42fda1b9a7a11fc3976e6bea93d70cf4c36 }
 
 vendor_package:
   - name: musl

--- a/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -461,30 +461,7 @@ module ${cfg['name']}_wrapper (
   // Accelerator instances if there are accelerator ports
   // If there are not accelerator ports, we tie the input signals to 0
 % for idx, c in enumerate(cfg['cores']):
-  % if c['snax_acc'] == "snax_gemm_wrapper":
-  ${c['snax_acc']} # (
-    .DataWidth ( ${cfg['pkg_name']}::NarrowDataWidth ),
-    .SnaxTcdmPorts ( SnaxTcdmPorts[${idx}] ),
-    .acc_req_t ( ${cfg['pkg_name']}::acc_req_t ),
-    .acc_rsp_t ( ${cfg['pkg_name']}::acc_resp_t ),
-    .tcdm_req_t ( ${cfg['pkg_name']}::tcdm_req_t ),
-    .tcdm_rsp_t ( ${cfg['pkg_name']}::tcdm_rsp_t )
-  ) i_${c['snax_acc']}_${idx}  (
-    .clk_i ( clk_i ),
-    .rst_ni ( rst_ni ),
-    .snax_req_i ( snax_req[${idx}] ),
-    .snax_qvalid_i ( snax_qvalid[${idx}] ),
-    .snax_qready_o ( snax_qready[${idx}] ),
-    .snax_resp_o ( snax_resp[${idx}] ),
-    .snax_pvalid_o ( snax_pvalid[${idx}] ),
-    .snax_pready_i ( snax_pready[${idx}] ),
-    .snax_tcdm_req_o ( snax_tcdm_req[${offset_list[idx+1]-1}:${offset_list[idx]}] ),
-    .snax_tcdm_rsp_i ( snax_tcdm_rsp[${offset_list[idx+1]-1}:${offset_list[idx]}] )
-  );
-
-  assign snax_barrier[${idx}] = '0;
-
-  % elif c['snax_acc'] != "none":
+  % if c['snax_acc'] != "none":
 
   ${c['snax_acc']} # (
     .DataWidth ( ${cfg['pkg_name']}::NarrowDataWidth ),

--- a/target/snitch_cluster/sw/snax/gemm/src/snax-gemm-lib.c
+++ b/target/snitch_cluster/sw/snax/gemm/src/snax-gemm-lib.c
@@ -172,13 +172,10 @@ void start_batch_gemm() {
 void wait_batch_gemm() {
     uint32_t break_poll;
 
-    while (1) {
-        // poll the state CSR[1] to see if GEMM is still busy
-        break_poll = read_csr(0x3cf);
-        if ((break_poll >> 1) == 1) {
-            break;
-        };
-    };
+    // Enable SNAX barrier
+    write_csr(0x7c3, 1);
+    // Trigger SNAX barrier
+    write_csr(0x7c4, 0);
 }
 
 uint32_t check_result(int32_t* output, int32_t* output_golden, uint8_t Batch,


### PR DESCRIPTION
This PR is a small fix because last time the barrier was only working for the MAC engine because we needed the update from the SNAX GEMM repo.

@xiaoling-yi made the update to add the `snax_barrier_o` signal already so this is just an upgrade to that.

The modifications are:
1. Use latest snax-gemm repo
2. Change template to default one
3. Modify the `wait_batch_gemm()` function to use the SNAX barrier.