### PR TITLE
Fix CI for docs build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -21,6 +21,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GH_TOKEN }}
+      - name: Install mkdocs modules
+        run: |
+          pip3 install -r docs/requirements.txt
       - name: Build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
This PR tries to fix the CI of the doc build because the packages were previously separated in #78.