### PR TITLE
docker: live at head

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: snax
+  IMAGE_NAME: kuleuven-micas/snax
 jobs:
   build-docker:
     name: Deploy Docker image

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: snax
 jobs:
   build-docker:
     name: Deploy Docker image

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v3
       - name: GHCR Log-in
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -31,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}          
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - 'util/container/Dockerfile'
   workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   build-docker:
     name: Deploy Docker image
@@ -23,7 +26,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,6 +7,9 @@ name: build-docker
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - 'util/container/Dockerfile'
   workflow_dispatch:
 jobs:
   build-docker:
@@ -14,19 +17,23 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v3
       - name: GHCR Log-in
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GH_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}          
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           file: util/container/Dockerfile
           push: true
-          tags: ghcr.io/kuleuven-micas/snax:latest
-          build-args: |-
-            SNITCH_LLVM_VERSION=latest
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Simulate SW on Snitch Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:latest
+      image: ghcr.io/kuleuven-micas/snax:pr-96
     steps:
       - uses: actions/checkout@v2
         with:
@@ -64,7 +64,7 @@ jobs:
     name: Simulate SW on SNAX MAC Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:latest
+      image: ghcr.io/kuleuven-micas/snax:pr-96
     steps:
       - uses: actions/checkout@v2
         with:
@@ -90,7 +90,7 @@ jobs:
     name: Simulate SW on SNAX MAC Cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:latest
+      image: ghcr.io/kuleuven-micas/snax:pr-96
     steps:
       - uses: actions/checkout@v2
         with:
@@ -115,7 +115,7 @@ jobs:
     name: Simulate SW on SNAX GEMM Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:latest
+      image: ghcr.io/kuleuven-micas/snax:pr-96
     steps:
       - uses: actions/checkout@v2
         with:
@@ -141,7 +141,7 @@ jobs:
     name: Simulate SW on SNAX GEMM Cluster w/ Verilator (Generic LLVM
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:latest
+      image: ghcr.io/kuleuven-micas/snax:pr-96
     steps:
       - uses: actions/checkout@v2
         with:
@@ -166,7 +166,7 @@ jobs:
     name: Simulate SW on SNAX Streamer GEMM Cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:latest
+      image: ghcr.io/kuleuven-micas/snax:pr-96
     steps:
       - uses: actions/checkout@v2
         with:
@@ -191,7 +191,7 @@ jobs:
     name: Simulate SW on SNAX Multiple MAC Cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:latest
+      image: ghcr.io/kuleuven-micas/snax:pr-96
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac.hjson \
-          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster
@@ -104,7 +103,6 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-gemm.hjson \
-          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster
@@ -130,7 +128,6 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-streamer-gemm.hjson \
-          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster
@@ -156,7 +153,6 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac-mult.hjson \
-          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac.hjson \
+          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster
@@ -103,6 +104,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-gemm.hjson \
+          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster
@@ -128,6 +130,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-streamer-gemm.hjson \
+          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster
@@ -153,6 +156,7 @@ jobs:
       - name: Build Hardware
         run: |
           make CFG_OVERRIDE=cfg/snax-mac-mult.hjson \
+          VLT_USE_LLVM=ON \
           -C target/snitch_cluster bin/snitch_cluster.vlt
       - name: Run Tests
         working-directory: target/snitch_cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Simulate SW on Snitch Cluster w/ Verilator
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:pr-96
+      image: ghcr.io/pulp-platform/snitch_cluster:main
     steps:
       - uses: actions/checkout@v2
         with:
@@ -60,32 +60,6 @@ jobs:
   # Simulate SW on SNAX Cluster w/ Verilator #
   ##############################################
 
-  sw-snax-mac-cluster-vlt:
-    name: Simulate SW on SNAX MAC Cluster w/ Verilator
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/kuleuven-micas/snax:pr-96
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
-      - name: Install DNN Python Modules
-        run: |
-          pip3 install -r sw/dnn/requirements.txt
-      - name: Build Software
-        run: |
-          make CFG_OVERRIDE=cfg/snax-mac.hjson -C target/snitch_cluster sw
-      - name: Build Hardware
-        run: |
-          make CFG_OVERRIDE=cfg/snax-mac.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
-      - name: Run Tests
-        working-directory: target/snitch_cluster
-        run: |-
-          ./run.py --simulator verilator \
-          sw/runtime.yaml sw/custom-fp.yaml sw/standard-fp.yaml \
-          sw/openmp.yaml sw/blas.yaml sw/dnn.yaml sw/snax-mac-run.yaml -j
-
   sw-snax-mac-cluster-vlt-generic:
     name: Simulate SW on SNAX MAC Cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
@@ -111,34 +85,8 @@ jobs:
           ./run.py --simulator verilator \
           sw/runtime.yaml sw/standard-fp.yaml sw/snax-mac-run.yaml -j
 
-  sw-snax-gemm-cluster-vlt:
-    name: Simulate SW on SNAX GEMM Cluster w/ Verilator
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/kuleuven-micas/snax:pr-96
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
-      - name: Install DNN Python Modules
-        run: |
-          pip3 install -r sw/dnn/requirements.txt
-      - name: Build Software
-        run: |
-          make CFG_OVERRIDE=cfg/snax-gemm.hjson -C target/snitch_cluster sw
-      - name: Build Hardware
-        run: |
-          make CFG_OVERRIDE=cfg/snax-gemm.hjson \
-          -C target/snitch_cluster bin/snitch_cluster.vlt
-      - name: Run Tests
-        working-directory: target/snitch_cluster
-        run: |-
-          ./run.py --simulator verilator \
-          sw/runtime.yaml sw/custom-fp.yaml sw/standard-fp.yaml \
-          sw/openmp.yaml sw/blas.yaml sw/dnn.yaml sw/snax-gemm-run.yaml -j
-
   sw-snax-gemm-cluster-vlt-generic:
-    name: Simulate SW on SNAX GEMM Cluster w/ Verilator (Generic LLVM
+    name: Simulate SW on SNAX GEMM Cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/kuleuven-micas/snax:pr-96

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -44,6 +44,15 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
 
 RUN apt-get install -y sbt
 
+# Install pip3
+RUN apt-get install -y python3-pip
+
+# Install Python Requirements from kuleuven-micas/snitch_cluster
+RUN git clone https://github.com/kuleuven-micas/snitch_cluster.git
+RUN cd snitch_cluster && pip3 install -r python-requirements.txt
+RUN cd ..
+RUN rm -rf snitch_cluster
+
 # Install the FIRRTL Compiler
 RUN wget https://github.com/llvm/circt/releases/download/firtool-1.73.0/firrtl-bin-linux-x64.tar.gz && \
     tar -xvzf firrtl-bin-linux-x64.tar.gz && \

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -25,11 +25,11 @@ RUN apt-get update && apt-get upgrade -y && \
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup install 1.76.0
-RUN rustup override set 1.76.0
+RUN rustup install 1.77.2
+RUN rustup override set 1.77.2
 
 # Install Bender
-RUN cargo install bender --version 0.27.1
+RUN cargo install bender --version 0.28.1
 
 # Install Verilator
 RUN apt-get install -y \
@@ -47,6 +47,14 @@ RUN git clone https://github.com/verilator/verilator && \
     cd .. && \
     rm -rf verilator
 ENV VLT_ROOT /usr/local/share/verilator
+
+# Install Verible
+ENV VERIBLE_VERSION 0.0-3644-g6882622d
+RUN wget https://github.com/chipsalliance/verible/releases/download/v${VERIBLE_VERSION}/verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz && \
+    mkdir tempdir && \
+    tar -x -f verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz --strip-components=1 -C tempdir && \
+    cp -rn tempdir/bin/* ./bin/ && \
+    rm -rf verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz tempdir
 
 # Install LLVM 17 + MLIR + clang-format
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -30,8 +30,8 @@ RUN cargo install bender --version 0.27.1
 # Install Verilator
 RUN apt-get install -y \
     git help2man perl make autoconf g++ flex bison ccache \
-    libgoogle-perftools-dev numactl perl-doc \
-    libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+    libgoogle-perftools-dev numactl perl-doc
+RUN apt-get install -y libfl2 libfl-dev zlibc zlib1g zlib1g-dev || true
 RUN git clone https://github.com/verilator/verilator && \
     cd verilator && \
     git checkout stable && \

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -29,8 +29,9 @@ RUN cargo install bender --version 0.27.1
 # Install Verilator
 RUN apt-get install -y verilator
 
-# Install LLVM 17
-RUN  wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh
+# Install LLVM 17 + MLIR
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh
+RUN apt-get -y install mlir-17-tools
 
 # Install the Chisel Environment
 RUN apt-get update && \

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -1,3 +1,7 @@
+# Copyright 2020 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ubuntu:22.04 AS builder
 
 # apt update and upgrade

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -1,17 +1,7 @@
-# Copyright 2020 ETH Zurich and University of Bologna.
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
+FROM ubuntu:22.04 AS builder
 
-# Docker container for Snitch development.
-
-# 1. Stage
-FROM ubuntu:18.04 AS builder
-ARG CMAKE_VERSION=3.19.4
-
-COPY apt-requirements.txt /tmp/apt-requirements.txt
-RUN apt-get update && \
-    sed 's/#.*//' /tmp/apt-requirements.txt \
-        | xargs apt-get install -y && \
+# apt update and upgrade
+RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
         build-essential \
         curl \
@@ -19,119 +9,32 @@ RUN apt-get update && \
         gnupg2 \
         lsb-release \
         software-properties-common \
+        tar \
         unzip \
         wget \
-        zlib1g-dev
+        zlib1g-dev \
+        zsh \
+        vim \
+        nano 
 
-# Build Rust tools
+# Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH "/root/.cargo/bin:${PATH}"
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install 1.76.0
 RUN rustup override set 1.76.0
 
 # Install Bender
 RUN cargo install bender --version 0.27.1
 
-# Get LLVM 12
-RUN wget https://apt.llvm.org/llvm.sh
-RUN chmod +x llvm.sh
-RUN ./llvm.sh 12
-
-WORKDIR /tools
-
-# Install a newer version of cmake (we need this for banshee)
-RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
-    tar -x -f cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz --strip-components=1 -C . && \
-    rm -rf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
-ENV PATH "/tools/bin:${PATH}"
-
-# Install `banshee` (needs cmake)
-RUN rustup install 1.63.0
-RUN rustup override set 1.63.0
-RUN git clone https://github.com/pulp-platform/banshee.git /tmp/banshee --recurse-submodules
-RUN cargo install --path /tmp/banshee
-
-# 2. Stage
-FROM ubuntu:18.04 AS snitch_cluster
-ARG SNITCH_LLVM_VERSION=latest
-ARG VERIBLE_VERSION=0.0-776-g09e0b87
-ARG VERILATOR_VERSION=4.100
-
-LABEL version="0.1"
-LABEL description="Snitch container for hardware and software development."
-LABEL maintainer="zarubaf@iis.ee.ethz.ch"
-LABEL org.opencontainers.image.source https://github.com/pulp-platform/snitch_cluster
-
-WORKDIR /tools
-
-# Install (and cleanup) required packages (from apt-requirements.txt)
-# The list of extra packages is leftover from before this Dockerfile used
-# apt-requirements.txt
-#
-COPY apt-requirements.txt /tmp/apt-requirements.txt
-RUN apt-get update && \
-    sed 's/#.*//' /tmp/apt-requirements.txt \
-        | xargs apt-get install -y && \
-    apt-get install -y --no-install-recommends \
-        gnupg2 \
-        curl \
-        wget \
-        git && \
-    apt-get clean ; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
-
 # Install Verilator
-RUN echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_18.04/ /' | tee /etc/apt/sources.list.d/home:phiwag:edatools.list && \
-    curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_18.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null && \
-    apt-get update && apt-get install -y verilator-${VERILATOR_VERSION} && \
-    apt-get clean ; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
-ENV VLT_ROOT "/usr/share/verilator"
+RUN apt-get install -y verilator
 
-# Install Python requirements
-COPY python-requirements.txt /tmp/python-requirements.txt
-COPY docs/requirements.txt /tmp/docs/requirements.txt
-# COPY sw/dnn/requirements.txt /tmp/sw/dnn/requirements.txt
-RUN pip3 install -r /tmp/python-requirements.txt --no-cache-dir
+# Install LLVM 17
+RUN  wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh
 
-# Get the precompiled LLVM toolchain
-RUN latest_tag=`curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/pulp-platform/llvm-project/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'` && \
-    echo "SNITCH_LLVM_VERSION=${SNITCH_LLVM_VERSION} LLVM_TAR=${LLVM_TAR} latest_tag=${latest_tag}" && \
-    test "${SNITCH_LLVM_VERSION}" = "latest" && SNITCH_LLVM_VERSION=${latest_tag} || : ; \
-    LLVM_TAR=riscv32-pulp-llvm-ubuntu1804-$(echo $SNITCH_LLVM_VERSION | cut -d '-' -f3-).tar.gz && \
-    mkdir -p riscv-llvm && \
-    echo "SNITCH_LLVM_VERSION=${SNITCH_LLVM_VERSION} LLVM_TAR=${LLVM_TAR} latest_tag=${latest_tag}" && \
-    wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/${SNITCH_LLVM_VERSION}/${LLVM_TAR} | \
-    tar xvz --strip-components=1 -C riscv-llvm
-ENV LLVM_BINROOT "/tools/riscv-llvm/bin"
-
-# Install Verible
-RUN wget https://github.com/google/verible/releases/download/v${VERIBLE_VERSION}/verible-v${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz && \
-    tar -x -f verible-v${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz --strip-components=1 -C . && \
-    rm -rf verible-v${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz
-ENV PATH "/tools/bin:${PATH}"
-
-# Install git>=2.18, required by Github checkout action to recurse submodules
-RUN apt-get update && apt-get install software-properties-common -y && \
-    add-apt-repository -y ppa:git-core/ppa && \
-    apt-get update && \
-    apt-get install git -y
-
-# Copy artifacts from stage 1.
-COPY --from=builder /root/.cargo/bin/bender bin/
-COPY --from=builder /root/.cargo/bin/banshee bin/
-
-# Set locale to UTF-8, required because Python 3.6 defaults on ASCII encoding.
-# See https://click.palletsprojects.com/en/8.1.x/unicode-support/
-ENV LC_ALL "C.UTF-8"
-ENV LANG   "C.UTF-8"
-
-# Install Chisel Environment
-
+# Install the Chisel Environment
 RUN apt-get update && \
     apt-get install -y openjdk-11-jre-headless openjdk-11-jdk-headless
-
-RUN apt-get install -y curl wget tar gnupg2
 
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
@@ -140,13 +43,16 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
 
 RUN apt-get install -y sbt
 
-RUN wget https://github.com/llvm/circt/releases/download/firtool-1.42.0/firrtl-bin-ubuntu-20.04.tar.gz && \
-    tar -xvzf firrtl-bin-ubuntu-20.04.tar.gz && \
-    rm firrtl-bin-ubuntu-20.04.tar.gz
+# Install the FIRRTL Compiler
+RUN wget https://github.com/llvm/circt/releases/download/firtool-1.73.0/firrtl-bin-linux-x64.tar.gz && \
+    tar -xvzf firrtl-bin-linux-x64.tar.gz && \
+    rm firrtl-bin-linux-x64.tar.gz
+ 
+# Install Oh-My-Zsh and Autocomplete Plugin
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+RUN echo "source ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc
+RUN chsh -s $(which zsh)
 
-# Install generic LLVM toolchain in /usr/bin - latest stable release is 17
-RUN  wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh && \
-# Replace standard verilator g++ compiler with clang++-17 instead
-sed -i 's/AR = ar/AR = llvm-ar-17/g; s/CXX = g++/CXX = clang++-17/g; s/LINK = g++/LINK = ld.lld-17/g' /usr/share/verilator/include/verilated.mk
-
-ENV PATH "/tools/firtool-1.42.0/bin/:${PATH}"
+# Zsh as default shell
+CMD ["zsh"]

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -29,9 +29,13 @@ RUN cargo install bender --version 0.27.1
 # Install Verilator
 RUN apt-get install -y verilator
 
-# Install LLVM 17 + MLIR
+# Install LLVM 17 + MLIR + clang-format
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh
 RUN apt-get -y install mlir-17-tools
+RUN apt-get -y install clang-format-17
+
+# create symbolic links for all *-17 binaries
+RUN for f in /usr/bin/*-17; do ln -s $f ${f%-17}; done
 
 # Install the Chisel Environment
 RUN apt-get update && \

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:22.04 AS builder
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
         build-essential \
+        device-tree-compiler \
         curl \
         git \
         gnupg2 \
@@ -27,7 +28,21 @@ RUN rustup override set 1.76.0
 RUN cargo install bender --version 0.27.1
 
 # Install Verilator
-RUN apt-get install -y verilator
+RUN apt-get install -y \
+    git help2man perl make autoconf g++ flex bison ccache \
+    libgoogle-perftools-dev numactl perl-doc \
+    libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+RUN git clone https://github.com/verilator/verilator && \
+    cd verilator && \
+    git checkout stable && \
+    unset VERILATOR_ROOT && \
+    autoconf && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -rf verilator
+ENV VLT_ROOT /usr/local/share/verilator
 
 # Install LLVM 17 + MLIR + clang-format
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh
@@ -58,9 +73,10 @@ RUN cd ..
 RUN rm -rf snitch_cluster
 
 # Install the FIRRTL Compiler
-RUN wget https://github.com/llvm/circt/releases/download/firtool-1.73.0/firrtl-bin-linux-x64.tar.gz && \
-    tar -xvzf firrtl-bin-linux-x64.tar.gz && \
-    rm firrtl-bin-linux-x64.tar.gz
+RUN wget https://github.com/llvm/circt/releases/download/firtool-1.42.0/firrtl-bin-ubuntu-20.04.tar.gz && \
+    tar -xvzf firrtl-bin-ubuntu-20.04.tar.gz && \
+    rm firrtl-bin-ubuntu-20.04.tar.gz
+ENV PATH="/firtool-1.42.0//bin:${PATH}"
  
 # Install Oh-My-Zsh and Autocomplete Plugin
 RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended


### PR DESCRIPTION
This PR marks the beginning of the unified docker container crusade ✝️ 

Changes in this PR:

- ubuntu 18 -> ubuntu 22
- verilator 4 -> most recent stable version
- multiple make versions -> one correct version of make
- custom llvm versions -> all to a generic llvm 17 toolchain
- change CI to test non-`llvm-generic` snitch tests with pulp-platform/snitch_cluster
- only run snax tests using our own `llvm-generic` runtime

Changes I forsee following PRs:
- updating chisel & firttl to a more recent version
- adding example prebuilt systems (copy from snax-mlir)
- every other possible repo that remains to use this one docker
- a penalty system for everybody that uses something else
