### PR TITLE
make compatible with verilator 5

### DIFF
--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -72,7 +72,11 @@ VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += +define+SYNTHESIS
 VLT_FLAGS    += --unroll-count 1024
-VLT_CFLAGS   += -std=c++20 -pthread
+ifeq ($VERILATOR_VERSION, 5)
+	VLT_FLAGS += -std=c++20 -pthread
+else 
+	VLT_FLAGS += -std=c++14 -pthread
+endif
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
 
 ANNOTATE_FLAGS ?= -q --keep-time
@@ -98,7 +102,7 @@ ifeq ($(VLT_USE_LLVM),ON)
     CC         = $(CLANG_CC)
     CXX        = $(CLANG_CXX)
     CFLAGS     = $(CLANG_CXXFLAGS)
-    CXXFLAGS   = $(CLANG_CXXFLAGS)
+    # CXXFLAGS   = $(CLANG_CXXFLAGS)
     LDFLAGS    = $(CLANG_LDFLAGS)
     VLT_FLAGS += --compiler clang
     VLT_FLAGS += -CFLAGS "${CLANG_CXXFLAGS}"

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -33,7 +33,7 @@ EVENTVIS_PY      ?= $(UTIL_DIR)/trace/eventvis.py
 
 VERILATOR_ROOT ?= $(dir $(shell $(VERILATOR_SEPP) which verilator))..
 VLT_ROOT       ?= ${VERILATOR_ROOT}
-VERILATOR_VERSION ?= $(shell verilator --version | grep -oP 'Verilator \K\d+')
+VERILATOR_VERSION ?= $(shell $(VLT) --version | grep -oP 'Verilator \K\d+')
 
 MATCH_END := '/+incdir+/ s/$$/\/*\/*/'
 MATCH_BGN := 's/+incdir+//g'
@@ -72,7 +72,7 @@ VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += +define+SYNTHESIS
 VLT_FLAGS    += --unroll-count 1024
-ifeq ($VERILATOR_VERSION, 5)
+ifeq ($(VERILATOR_VERSION), 5)
 	VLT_CFLAGS += -std=c++20 -pthread
 else 
 	VLT_CFLAGS += -std=c++14 -pthread

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -33,6 +33,7 @@ EVENTVIS_PY      ?= $(UTIL_DIR)/trace/eventvis.py
 
 VERILATOR_ROOT ?= $(dir $(shell $(VERILATOR_SEPP) which verilator))..
 VLT_ROOT       ?= ${VERILATOR_ROOT}
+VERILATOR_VERSION ?= $(shell verilator --version | grep -oP 'Verilator \K\d+')
 
 MATCH_END := '/+incdir+/ s/$$/\/*\/*/'
 MATCH_BGN := 's/+incdir+//g'
@@ -57,7 +58,9 @@ VLT_BENDER   += -t rtl
 VLT_SOURCES   = $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
 VLT_BUILDDIR := work-vlt
 VLT_FESVR     = $(VLT_BUILDDIR)/riscv-isa-sim
-VLT_FLAGS	 += --timing
+ifeq ($(VERILATOR_VERSION), 5)
+	VLT_FLAGS += --timing
+endif
 VLT_FLAGS    += -Wno-BLKANDNBLK
 VLT_FLAGS    += -Wno-LITENDIAN
 VLT_FLAGS    += -Wno-CASEINCOMPLETE

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -102,7 +102,7 @@ ifeq ($(VLT_USE_LLVM),ON)
     CC         = $(CLANG_CC)
     CXX        = $(CLANG_CXX)
     CFLAGS     = $(CLANG_CXXFLAGS)
-    # CXXFLAGS   = $(CLANG_CXXFLAGS)
+    CXXFLAGS   = $(CLANG_CXXFLAGS)
     LDFLAGS    = $(CLANG_LDFLAGS)
     VLT_FLAGS += --compiler clang
     VLT_FLAGS += -CFLAGS "${CLANG_CXXFLAGS}"

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -72,7 +72,7 @@ VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += +define+SYNTHESIS
 VLT_FLAGS    += --unroll-count 1024
-VLT_CFLAGS   += -std=c++14 -pthread
+VLT_CFLAGS   += -std=c++14 -pthread -fcoroutines
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
 
 ANNOTATE_FLAGS ?= -q --keep-time

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -73,9 +73,9 @@ VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += +define+SYNTHESIS
 VLT_FLAGS    += --unroll-count 1024
 ifeq ($VERILATOR_VERSION, 5)
-	VLT_FLAGS += -std=c++20 -pthread
+	VLT_CFLAGS += -std=c++20 -pthread
 else 
-	VLT_FLAGS += -std=c++14 -pthread
+	VLT_CFLAGS += -std=c++14 -pthread
 endif
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
 

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -72,7 +72,7 @@ VLT_FLAGS    += -Wno-UNOPTFLAT
 VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += +define+SYNTHESIS
 VLT_FLAGS    += --unroll-count 1024
-VLT_CFLAGS   += -std=c++14 -pthread -fcoroutines
+VLT_CFLAGS   += -std=c++20 -pthread
 VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR) -I ${MKFILE_DIR}/test
 
 ANNOTATE_FLAGS ?= -q --keep-time

--- a/target/common/common.mk
+++ b/target/common/common.mk
@@ -57,6 +57,7 @@ VLT_BENDER   += -t rtl
 VLT_SOURCES   = $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
 VLT_BUILDDIR := work-vlt
 VLT_FESVR     = $(VLT_BUILDDIR)/riscv-isa-sim
+VLT_FLAGS	 += --timing
 VLT_FLAGS    += -Wno-BLKANDNBLK
 VLT_FLAGS    += -Wno-LITENDIAN
 VLT_FLAGS    += -Wno-CASEINCOMPLETE

--- a/target/snitch_cluster/Makefile
+++ b/target/snitch_cluster/Makefile
@@ -130,6 +130,10 @@ VLT_COBJ += $(VLT_BUILDDIR)/tb/tb_bin.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_dpi.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_vcd_c.o
+ifeq ($(VERILATOR_VERSION), 5)
+	VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_timing.o
+	VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_threads.o
+endif
 # Bootdata
 VLT_COBJ += $(VLT_BUILDDIR)/generated/bootdata.o
 


### PR DESCRIPTION
changes:

- add `--timing` flag (which is now required)
- add required cobj arguments
- update c++ version