### PR TITLE
add snax repository structure to documentation

### DIFF
--- a/docs/ug/directory_structure.md
+++ b/docs/ug/directory_structure.md
@@ -1,7 +1,37 @@
 # Directory Structure
 
 The project is organized as a monolithic repository. Both hardware and software
-are co-located. The top-level ist structured as follows:
+are co-located. 
+
+The file tree is visualized as follows:
+
+```
+├── hw
+│   ├── chisel
+│   │   ├── csr_manager
+│   │   └── streamer
+│   ├── snax_accelerator_1
+│   ├── snax_accelerator_2
+│   ├── snitch_stuff
+│   └── templates
+├── sw
+├── target
+│   └── snitch_cluster
+│       ├── config
+│       ├── generated
+│       └── sw
+│           ├── apps
+│           │   ├── snax_system_1
+│           │   └── snax_system_2
+│           └── snax_lib 
+│               ├── snax_system_1
+│               └── snax_system_2
+└── util
+    ├── clustergen
+    └── wrappergen
+```
+
+The top-level is structured as follows:
 
 * `docs`: [Documentation](documentation.md) of the generator and software.
   Contains additional user guides.

--- a/docs/ug/directory_structure.md
+++ b/docs/ug/directory_structure.md
@@ -5,7 +5,7 @@ are co-located. The top-level ist structured as follows:
 
 * `docs`: [Documentation](documentation.md) of the generator and software.
   Contains additional user guides.
-* `hw`: All hardware IP components.
+* `hw`: All hardware IP components. The source files are either specified by SystemVerilog, Chisel, or a template to generate these files.
 * `sw`: Hardware independent software, libraries, runtimes etc.
 * `target`: Contains the testbench setup, cluster configuration specific hardware and software, libraries, runtimes etc.
 * `util`: Utility and helper scripts.
@@ -17,6 +17,16 @@ The following documentation is directly included from `../../hw/README.md`
 {%
    include-markdown '../../hw/README.md'
    start="# Snitch Hardware"
+   comments=false
+%}
+
+## Target `target` Directory
+<!---
+The following documentation is directly included from `../../sw/README.md`
+-->
+{%
+   include-markdown '../../target/README.md'
+   start="# HW Targets"
    comments=false
 %}
 
@@ -33,13 +43,3 @@ The following documentation is directly included from `../../sw/README.md`
    comments=false
 %}
 
-
-## Target `target` Directory
-<!---
-The following documentation is directly included from `../../sw/README.md`
--->
-{%
-   include-markdown '../../target/README.md'
-   start="# HW Targets"
-   comments=false
-%}

--- a/hw/README.md
+++ b/hw/README.md
@@ -10,7 +10,7 @@ Some of the IPs have stand-alone test benches. The top level structure of the `h
 
 All IPs inside the `hw` directory are structured as follows:
 
-- `<ip_name>`: each directory contains one IP that is instantiated in the cluster design, e.g., they are not stand-alone.
+- `<ip_name>`: each directory contains one IP that is instantiated in the cluster design
   - `doc`: documentation if existing
   - `src`: RTL sources
   - `test`: Standalone testbenches if existing

--- a/hw/README.md
+++ b/hw/README.md
@@ -6,7 +6,7 @@ Some of the IPs have stand-alone test benches. The top level structure of the `h
 - `<snitch_ip>`: IP components for the snitch cluster
 - `chisel`: SNAX Framework componets written in the Chisel HDL.
 - `<snax_ip>`: SNAX Accelerators 
-- `templates`: Template files which are used to generate the snax wrappers based on the supplied config files.
+- `templates`: Template files which are used to generate the snax wrappers and Chisel parameters based on the supplied config files.
 
 All IPs inside the `hw` directory are structured as follows:
 
@@ -15,3 +15,10 @@ All IPs inside the `hw` directory are structured as follows:
   - `src`: RTL sources
   - `test`: Standalone testbenches if existing
   - `util`: Helper scripts to run standalone test benches if existing
+
+The exact structure for `chisel` differs from this, but is very similar:
+
+- `chisel`
+  - `doc`: documentation 
+  - `src/main/scala/snax/<component>`: RTL sources
+  - `src/test/scala/snax/<component>`: Standalone testbenches

--- a/hw/README.md
+++ b/hw/README.md
@@ -1,7 +1,14 @@
 # Snitch Hardware
 
 The `hw` directory contains various HW IPs which are instantiated in the Snitch Cluster design e.g., they are not stand-alone.
-Some of the IPs have stand-alone test benches. All IPs inside the `hw` directory are structured as follows:
+Some of the IPs have stand-alone test benches. The top level structure of the `hw` folder is as follows:
+
+- `<snitch_ip>`: IP components for the snitch cluster
+- `chisel`: SNAX Framework componets written in the Chisel HDL.
+- `<snax_ip>`: SNAX Accelerators 
+- `templates`: Template files which are used to generate the snax wrappers based on the supplied config files.
+
+All IPs inside the `hw` directory are structured as follows:
 
 - `<ip_name>`: each directory contains one IP that is instantiated in the cluster design, e.g., they are not stand-alone.
   - `doc`: documentation if existing

--- a/target/README.md
+++ b/target/README.md
@@ -4,8 +4,14 @@ This subdirectory contains the supported systems and their simulation environmen
 
   - `shared`: contains the shared fesvr related testbench components.
   - `snitch_cluster`
-    - `cfg`: containing the configuration files `*.hsjon`.
-    - `generated`: contains the generated `bootdata.cc` and RTL wrapper for the snitch cluster `snitch_cluster_wrapper.sv`.
+    - `cfg`: containing the configuration files `*.hsjon` for a specific snax-cluster configuration. This is the only place where system specific parameters are set.
+    - `generated`: contains the generated `bootdata.cc` and wrapper files for the snax cluster.
+      - `snax-acc-1`
+        - `csr_wrapper.sv`
+        - `streamer_wrapper.sv`
+        - `top_wrapper.sv`
+        - `...`
+      - `snax-acc-2`
     - `src`: contains the [Banshee](https://github.com/pulp-platform/banshee) configuration for the snitch cluster.
     - `sw`: contains all shared
       - `apps`: contains applications for the snitch cluster.
@@ -13,4 +19,9 @@ This subdirectory contains the supported systems and their simulation environmen
         - `rtl`: RTL-related startup implmentations.
         - `banshee`: Banshee-related startup SW implmentations.
       - `tests`: lists of tests that can run on the snitch cluster.
+        - `snax-cluster-1`
+        - `snax-cluster-2`
+      - `snax-lib`: C libraries to run specific kernels on a snax-cluster.
+        - `snax-cluster-1`
+        - `snax-cluster-2`
     - `test`: contains testharness and bootrom of the snitch cluster


### PR DESCRIPTION
This PR adds the proposed directory structure ready for the tutorial.

Just for documentation purposes, you can view this locally in your localhost:

Install the docs requirements:

`pip3 install -r docs/requirements.txt`

Then run `mkdocs serve`. Do it in your own local Python environment. Conda or whatever is available 😄 