### PR TITLE
[docker] update chisel build method to what is recommmended

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
     name: Simulate SW on SNAX ALU Cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:pr-110
+      image: ghcr.io/kuleuven-micas/snax:main
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     branches: ["main"]
   pull_request:
 jobs:
-
   ########
   # Docs #
   ########
@@ -36,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Install DNN Python Modules
         run: |
           pip3 install -r sw/dnn/requirements.txt
@@ -55,7 +54,6 @@ jobs:
           sw/standard-fp.yaml sw/openmp.yaml sw/snitch-cluster-openmp.yaml \
           sw/blas.yaml sw/dnn.yaml -j
 
-
   ##############################################
   # Simulate SW on SNAX Cluster w/ Verilator #
   ##############################################
@@ -68,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
@@ -93,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
@@ -118,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
@@ -143,7 +141,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Build Software
         run: |
           make -C target/snitch_cluster sw \
@@ -165,7 +163,7 @@ jobs:
     name: Simulate SW on SNAX ALU Cluster w/ Verilator (Generic LLVM)
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:main
+      image: ghcr.io/kuleuven-micas/snax:pr-110
     steps:
       - uses: actions/checkout@v2
         with:
@@ -199,7 +197,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Install DNN Python Modules
         run: |
           pip3 install -r sw/dnn/requirements.txt

--- a/.github/workflows/scala-unit-test.yml
+++ b/.github/workflows/scala-unit-test.yml
@@ -16,10 +16,10 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/kuleuven-micas/snax:main
+      image: ghcr.io/kuleuven-micas/snax:pr-110
     steps:
       - uses: actions/checkout@v2
       - name: Run the unit tests
         working-directory: hw/chisel
         run: |
-          sbt test
+          mill Snax.test

--- a/hw/chisel/.gitignore
+++ b/hw/chisel/.gitignore
@@ -5,3 +5,5 @@ project/*
 target
 test_run_dir
 .bsp
+.scala-build
+out

--- a/hw/chisel/build.sbt
+++ b/hw/chisel/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / scalaVersion := "2.13.8"
 ThisBuild / version := "0.1.0"
 ThisBuild / organization := "be.kuleuven.esat.micas"
 
-val chiselVersion = "5.0.0"
+val chiselVersion = "6.3.0"
 
 lazy val root = (project in file("."))
   .settings(

--- a/hw/chisel/build.sbt
+++ b/hw/chisel/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
     name := "snax-streamer",
     libraryDependencies ++= Seq(
       "org.chipsalliance" %% "chisel" % chiselVersion,
-      "edu.berkeley.cs" %% "chiseltest" % "5.0.0" % "test"
+      "edu.berkeley.cs" %% "chiseltest" % "6.0.0" % "test"
     ),
     scalacOptions ++= Seq(
       "-language:reflectiveCalls",

--- a/hw/chisel/build.sc
+++ b/hw/chisel/build.sc
@@ -1,0 +1,31 @@
+// import Mill dependency
+import mill._
+import mill.define.Sources
+import mill.modules.Util
+import mill.scalalib.TestModule.ScalaTest
+import scalalib._
+// support BSP
+import mill.bsp._
+
+object Snax extends SbtModule { m =>
+  override def millSourcePath = os.pwd
+  override def scalaVersion = "2.13.12"
+  override def scalacOptions = Seq(
+    "-language:reflectiveCalls",
+    "-deprecation",
+    "-feature",
+    "-Xcheckinit",
+  )
+  override def ivyDeps = Agg(
+    ivy"org.chipsalliance::chisel:6.3.0",
+    ivy"edu.berkeley.cs::chiseltest:6.0.0",
+  )
+  override def scalacPluginIvyDeps = Agg(
+    ivy"org.chipsalliance:::chisel-plugin:6.3.0",
+  )
+  object test extends SbtModuleTests with TestModule.ScalaTest {
+    override def ivyDeps = m.ivyDeps() ++ Agg(
+      ivy"org.scalatest::scalatest::3.2.16"
+    )
+  }
+}

--- a/hw/chisel/build.sc
+++ b/hw/chisel/build.sc
@@ -4,10 +4,11 @@ import mill.define.Sources
 import mill.modules.Util
 import mill.scalalib.TestModule.ScalaTest
 import scalalib._
+import scalafmt._
 // support BSP
 import mill.bsp._
 
-object Snax extends SbtModule { m =>
+object Snax extends SbtModule with ScalafmtModule { m =>
   override def millSourcePath = os.pwd
   override def scalaVersion = "2.13.12"
   override def scalacOptions = Seq(

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -85,10 +85,10 @@ RUN cd ..
 RUN rm -rf snitch_cluster
 
 # Install the FIRRTL Compiler
-RUN wget https://github.com/llvm/circt/releases/download/firtool-1.42.0/firrtl-bin-ubuntu-20.04.tar.gz && \
-    tar -xvzf firrtl-bin-ubuntu-20.04.tar.gz && \
-    rm firrtl-bin-ubuntu-20.04.tar.gz
-ENV PATH="/firtool-1.42.0//bin:${PATH}"
+RUN wget https://github.com/llvm/circt/releases/download/firtool-1.62.0/firrtl-bin-linux-x64.tar.gz && \
+    tar -xvzf firrtl-bin-linux-x64.tar.gz && \
+    rm firrtl-bin-linux-x64.tar.gz
+ENV PATH="/firtool-1.62.0/bin:${PATH}"
  
 # Install Oh-My-Zsh and Autocomplete Plugin
 RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -6,21 +6,21 @@ FROM ubuntu:22.04 AS builder
 
 # apt update and upgrade
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y \
-        build-essential \
-        device-tree-compiler \
-        curl \
-        git \
-        gnupg2 \
-        lsb-release \
-        software-properties-common \
-        tar \
-        unzip \
-        wget \
-        zlib1g-dev \
-        zsh \
-        vim \
-        nano 
+  apt-get install -y \
+  build-essential \
+  device-tree-compiler \
+  curl \
+  git \
+  gnupg2 \
+  lsb-release \
+  software-properties-common \
+  tar \
+  unzip \
+  wget \
+  zlib1g-dev \
+  zsh \
+  vim \
+  nano 
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -33,28 +33,28 @@ RUN cargo install bender --version 0.28.1
 
 # Install Verilator
 RUN apt-get install -y \
-    git help2man perl make autoconf g++ flex bison ccache \
-    libgoogle-perftools-dev numactl perl-doc
+  git help2man perl make autoconf g++ flex bison ccache \
+  libgoogle-perftools-dev numactl perl-doc
 RUN apt-get install -y libfl2 libfl-dev zlibc zlib1g zlib1g-dev || true
 RUN git clone https://github.com/verilator/verilator && \
-    cd verilator && \
-    git checkout stable && \
-    unset VERILATOR_ROOT && \
-    autoconf && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install && \
-    cd .. && \
-    rm -rf verilator
+  cd verilator && \
+  git checkout stable && \
+  unset VERILATOR_ROOT && \
+  autoconf && \
+  ./configure && \
+  make -j$(nproc) && \
+  make install && \
+  cd .. && \
+  rm -rf verilator
 ENV VLT_ROOT /usr/local/share/verilator
 
 # Install Verible
 ENV VERIBLE_VERSION 0.0-3644-g6882622d
 RUN wget https://github.com/chipsalliance/verible/releases/download/v${VERIBLE_VERSION}/verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz && \
-    mkdir tempdir && \
-    tar -x -f verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz --strip-components=1 -C tempdir && \
-    cp -rn tempdir/bin/* ./bin/ && \
-    rm -rf verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz tempdir
+  mkdir tempdir && \
+  tar -x -f verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz --strip-components=1 -C tempdir && \
+  cp -rn tempdir/bin/* ./bin/ && \
+  rm -rf verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz tempdir
 
 # Install LLVM 17 + MLIR + clang-format
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh
@@ -66,12 +66,19 @@ RUN for f in /usr/bin/*-17; do ln -s $f ${f%-17}; done
 
 # Install the Chisel Environment
 RUN apt-get update && \
-    apt-get install -y openjdk-11-jre-headless openjdk-11-jdk-headless
+  apt-get install -y openjdk-11-jre-headless openjdk-11-jdk-headless
 
+# Install scala-cli
+RUN curl -sSLf https://scala-cli.virtuslab.org/get | sh
+
+# Install mill build tool
+RUN curl -L https://raw.githubusercontent.com/lefou/millw/0.4.11/millw > mill && chmod +x mill && mv mill /usr/local/bin
+
+# Install sbt
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
-    echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
-    apt-get update
+  echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
+  curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
+  apt-get update
 
 RUN apt-get install -y sbt
 
@@ -84,12 +91,6 @@ RUN cd snitch_cluster && pip3 install -r python-requirements.txt
 RUN cd ..
 RUN rm -rf snitch_cluster
 
-# Install the FIRRTL Compiler
-RUN wget https://github.com/llvm/circt/releases/download/firtool-1.62.0/firrtl-bin-linux-x64.tar.gz && \
-    tar -xvzf firrtl-bin-linux-x64.tar.gz && \
-    rm firrtl-bin-linux-x64.tar.gz
-ENV PATH="/firtool-1.62.0/bin:${PATH}"
- 
 # Install Oh-My-Zsh and Autocomplete Plugin
 RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 RUN git clone https://github.com/zsh-users/zsh-autosuggestions.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions

--- a/util/wrappergen/wrappergen.py
+++ b/util/wrappergen/wrappergen.py
@@ -53,10 +53,9 @@ def gen_file(cfg, tpl, target_path: str, file_name: str) -> None:
 
 
 def gen_chisel_file(chisel_path, chisel_param, gen_path):
-
     # Call chisel environment and generate the system verilog file
-    cmd = f' cd {chisel_path} && sbt \
-        "runMain {chisel_param} {gen_path}"'
+    cmd = f' cd {chisel_path} && \
+        mill "Snax.runMain {chisel_param} {gen_path}"'
     os.system(cmd)
 
     return
@@ -88,10 +87,7 @@ def main():
         help="Points to the streamer chisel source path",
     )
     parser.add_argument(
-        "--gen_path",
-        type=str,
-        default="./",
-        help="Points to the output directory"
+        "--gen_path", type=str, default="./", help="Points to the output directory"
     )
 
     # Get the list of parsing
@@ -130,8 +126,7 @@ def main():
         acc_cfgs[i]["tcdm_depth"] = tcdm_depth
         tcdm_num_banks = cfg["cluster"]["tcdm"]["banks"]
         acc_cfgs[i]["tcdm_num_banks"] = tcdm_num_banks
-        tcdm_addr_width = tcdm_num_banks * tcdm_depth * \
-            (tcdm_data_width // 8)
+        tcdm_addr_width = tcdm_num_banks * tcdm_depth * (tcdm_data_width // 8)
         tcdm_addr_width = int(math.log2(tcdm_addr_width))
         acc_cfgs[i]["tcdm_addr_width"] = tcdm_addr_width
         # Chisel parameter tag names
@@ -161,8 +156,7 @@ def main():
         )
 
         # CSR manager scala parameter generation
-        chisel_target_path = args.chisel_path + \
-            "src/main/scala/snax/csr_manager/"
+        chisel_target_path = args.chisel_path + "src/main/scala/snax/csr_manager/"
         file_name = "CsrManParamGen.scala"
         tpl_scala_param_file = args.tpl_path + "csrman_param_gen.scala.tpl"
         tpl_scala_param = get_template(tpl_scala_param_file)
@@ -187,10 +181,8 @@ def main():
         )
 
         # This first one generates the streamer wrapper
-        file_name = acc_cfgs[i]["snax_acc_name"] + \
-            "_streamer_wrapper.sv"
-        tpl_streamer_wrapper_file = args.tpl_path + \
-            "snax_streamer_wrapper.sv.tpl"
+        file_name = acc_cfgs[i]["snax_acc_name"] + "_streamer_wrapper.sv"
+        tpl_streamer_wrapper_file = args.tpl_path + "snax_streamer_wrapper.sv.tpl"
         tpl_streamer_wrapper = get_template(tpl_streamer_wrapper_file)
         gen_file(
             cfg=acc_cfgs[i],
@@ -201,8 +193,7 @@ def main():
 
         # This generates the top wrapper
         file_name = acc_cfgs[i]["snax_acc_name"] + "_wrapper.sv"
-        tpl_rtl_wrapper_file = args.tpl_path + \
-            "snax_acc_wrapper.sv.tpl"
+        tpl_rtl_wrapper_file = args.tpl_path + "snax_acc_wrapper.sv.tpl"
         tpl_rtl_wrapper = get_template(tpl_rtl_wrapper_file)
         gen_file(
             cfg=acc_cfgs[i],
@@ -214,15 +205,15 @@ def main():
         # Generate chisel component using chisel generation script
         gen_chisel_file(
             chisel_path=args.chisel_path,
-            chisel_param='snax.csr_manager.CsrManagerGen',
-            gen_path=rtl_target_path
+            chisel_param="snax.csr_manager.CsrManagerGen",
+            gen_path=rtl_target_path,
         )
 
         # Generate chisel component using chisel generation script
         gen_chisel_file(
             chisel_path=args.chisel_path,
-            chisel_param='snax.streamer.StreamerTopGen',
-            gen_path=rtl_target_path
+            chisel_param="snax.streamer.StreamerTopGen",
+            gen_path=rtl_target_path,
         )
 
     print("Generation done!")

--- a/util/wrappergen/wrappergen.py
+++ b/util/wrappergen/wrappergen.py
@@ -54,8 +54,9 @@ def gen_file(cfg, tpl, target_path: str, file_name: str) -> None:
 
 def gen_chisel_file(chisel_path, chisel_param, gen_path):
     # Call chisel environment and generate the system verilog file
-    cmd = f' cd {chisel_path} && \
-        mill "Snax.runMain {chisel_param} {gen_path}"'
+    cmd = f" cd {chisel_path} && \
+        mill Snax.runMain {chisel_param} {gen_path}"
+    print(cmd)
     os.system(cmd)
 
     return

--- a/util/wrappergen/wrappergen.py
+++ b/util/wrappergen/wrappergen.py
@@ -56,7 +56,6 @@ def gen_chisel_file(chisel_path, chisel_param, gen_path):
     # Call chisel environment and generate the system verilog file
     cmd = f" cd {chisel_path} && \
         mill Snax.runMain {chisel_param} {gen_path}"
-    print(cmd)
     os.system(cmd)
 
     return


### PR DESCRIPTION
The only thing that wasn't updated in #96 was the Chisel version.
This PR changes the way we build Chisel stuff to be up to date with what is recommended by the developers of Chisel.
( sorry for all the auto-formatting changes, we should standardize autoformatting for everything sometime)

## Problems

We currently have the following problems:
- We are not using the most recent Chisel version (6.3)
- We are not using `scala-cli`
[link](https://www.chisel-lang.org/docs/installation)
> As described above, Scala CLI is a great "batteries included" way to use Chisel. It will automatically download and manage all dependencies of Chisel including a Java Development Kit (JDK). More complex projects will require the user to install a JDK and a build tool.
With `scala-cli`, we don't have to manage everything manually, which is very nice
- We are using `sbt`
[link](https://www.chisel-lang.org/docs/installation)
> [Mill](https://mill-build.com/) is a modern Scala build tool with simple syntax and a better command-line experience than SBT. We recommend Chisel users use Mill.

Other people have quite [strong opinions](https://www.lihaoyi.com/post/SowhatswrongwithSBT.html) about sbt:
> sbt's syntax is just honestly sinful. It looks like something the germans would have come up with... 70 yrs ago... in a submarine.

Me personally, I have also ran into quite annoying problems with sbt, with no docs to solve these problems, so I hope mill is a better alternative

- We are using `ChiselTest`
[link](https://www.chisel-lang.org/docs/appendix/migrating-from-chiseltest)
> ChiselTest is not used or maintained by the core Chisel development team or their employers. ChiselSim is the approved replacement for ChiselTest in Chisel 5 and beyond. ChiselSim is maintained and used by the core Chisel development team. This page describes how to migrate from ChiselTest to ChiselSim.

However the state of ChiselSim seems to be even worse:
https://github.com/chipsalliance/chisel/discussions/3957
https://github.com/chipsalliance/chisel/discussions/4033

And berkeley seems to still put effort in ChiselTest, so let's keep using that.

## Solutions

Therefore the PR employs the following changes:

- use ChiselVersion 6.3 with ChiselTest 6.0
- add a build.sc to support builds with mill
- add scala-cli and mill to the docker build
- remove firttl from the docker build
- run CI using mill

## Results

This has the following advantages:

- automatic version resolution of the firttl compiler (no need to check correct version ourself)
- chisel 6 features (some new warnings are generated from things we do wrong :) )
- much faster builds with mill:
  - formatting: 8s -> 0.5s
  - compiling (no cache): 20s -> 11s
  - compiling (with cache): 10s -> 0.8s

## mill user guide

I kindly ask to test out the mill build tool instead of `sbt`, it results in much faster builds. Here is a short user guide to help with this conversion:

instead of `sbt runMain`, use:
```
mill Snax.runMain
```

instead of `sbt test`, use:
```
mill Snax.test
```

instead of `sbt testOnly`, use:
```
mill Snax.test.testOnly "snax.csr_manager.CsrManagerTest"
```

Formatting:
```
mill Snax.reformat
mill Snax.checkFormat
```

Check other commands with either
```
mill resolve Snax._
mill --help
```

## Todos

- [ ] after approval, reset docker tags to main