### PR TITLE
Add accelerator design tutorial

### DIFF
--- a/docs/tutorial/accelerator_design.md
+++ b/docs/tutorial/accelerator_design.md
@@ -1,15 +1,15 @@
 # Accelerator Design
 
-Let's first dive into the SNAX shell which is the encapsulated yellow-box from the main figure in [Architectural Overview](./architectural_overview.md). The figure below is the same shell but with more signal details:
+Let's first dive into the SNAX shell which is the encapsulated yellow box from the main figure in [Architectural Overview](./architectural_overview.md). The figure below is the same shell but with more signal details:
 
 
 We labeled a few important details about the shell:
 
 1 - The entire SNAX accelerator wrapper encapsulates the streamers, the CSR manager, and the accelerator data path.
 
-2 - The CSR manager handles the CSR read and write transactions between the Snitch core and the accelerator data path. Towards the Snitch core side, CSR transactions are handled with decoupled interfaces (`csr_req_*` and `csr_rsp_*`) of request and responses. Towards the accelerator side, the read-write registers (`register_rw_set`) uses a decoupled interface (`register_rw_valid` and `register_rw_ready`) while the read-only registers (`register_ro_set`) is a direct mapping. There are more details in [CSR Manager Design](./csrman_design.md).
+2 - The CSR manager handles the CSR read and write transactions between the Snitch core and the accelerator data path. Towards the Snitch core side, CSR transactions are handled with decoupled interfaces (`csr_req_*` and `csr_rsp_*`) of requests and responses. Towards the accelerator side, the read-write registers (`register_rw_set`) use a decoupled interface (`register_rw_valid` and `register_rw_ready`) while the read-only registers (`register_ro_set`) use a direct mapping. There are more details in [CSR Manager Design](./csrman_design.md).
 
-3 - The streamer provides flexible data access from the L1 TCDM to the accelerator. It serves as an intermediate interface ebtween the TCDM interconnect and the accelerator. On the interconnect side the streamer controls the TCDM request and response (`tcdm_req` and `tcdm_rsp`) interfaces towards the memory. On the accelerator side, the streamer has its own data decoupled interfaces (`acc2stream_*` and `stream2acc_*`). The direction from accelerator to streamer are write-only ports while the direction from streamer to accelerator are read-only ports. More details are in [Streamer Design](./streamer_design.md).
+3 - The streamer provides flexible data access from the L1 TCDM to the accelerator. It serves as an intermediate interface between the TCDM interconnect and the accelerator. On the interconnect side the streamer controls the TCDM request and response (`tcdm_req` and `tcdm_rsp`) interfaces towards the memory. On the accelerator side, the streamer has its own data decoupled interfaces (`acc2stream_*` and `stream2acc_*`). The direction from the accelerator to the streamer is write-only ports while the direction from the streamer to the accelerator is read-only ports. More details are in [Streamer Design](./streamer_design.md).
 
 4 - The accelerator data path is the focus of this section. In our example, we will use a very simple ALU datapath with basic operations only. The SNAX ALU is already built for you. You can find it under the `./hw/snax_alu/` directory. Take time to check the simple design.
 

--- a/docs/tutorial/accelerator_design.md
+++ b/docs/tutorial/accelerator_design.md
@@ -1,5 +1,36 @@
 # Accelerator Design
 
+Let's first dive into the SNAX shell which is the encapsulated yellow-box from the main figure in [Architectural Overview](./architectural_overview.md). The figure below is the same shell but with more signal details:
+
+
+We labeled a few important details about the shell:
+
+1 - The entire SNAX accelerator wrapper encapsulates the streamers, the CSR manager, and the accelerator data path.
+
+2 - The CSR manager handles the CSR read and write transactions between the Snitch core and the accelerator data path. Towards the Snitch core side, CSR transactions are handled with decoupled interfaces (`csr_req_*` and `csr_rsp_*`) of request and responses. Towards the accelerator side, the read-write registers (`register_rw_set`) uses a decoupled interface (`register_rw_valid` and `register_rw_ready`) while the read-only registers (`register_ro_set`) is a direct mapping. There are more details in [CSR Manager Design](./csrman_design.md).
+
+3 - The streamer provides flexible data access from the L1 TCDM to the accelerator. It serves as an intermediate interface ebtween the TCDM interconnect and the accelerator. On the interconnect side the streamer controls the TCDM request and response (`tcdm_req` and `tcdm_rsp`) interfaces towards the memory. On the accelerator side, the streamer has its own data decoupled interfaces (`acc2stream_*` and `stream2acc_*`). The direction from accelerator to streamer are write-only ports while the direction from streamer to accelerator are read-only ports. More details are in [Streamer Design](./streamer_design.md).
+
+4 - The accelerator data path is the focus of this section. In our example, we will use a very simple ALU datapath with basic operations only. The SNAX ALU is already built for you. You can find it under the `./hw/snax_alu/` directory. Take time to check the simple design.
+
+# SNAX ALU Accelerator Datapath
+
+The figure below shows the SNAX ALU datapath:
+
+Again, we label points of interest:
+
+1 - 
+
+## Accelerator Architecture
+
+## Modes and Features
+
+## Interfaces
+
+## Timing Diagrams
+
+
+
 ## TODOs:
 - Describe the accelerator of interest
 - Show a detailed block diagram of the signals
@@ -12,14 +43,3 @@
     - Counter
 - Have a timing diagram interface to describe what happens for the signals
 - Indicate which repository to see this structure
-
-## Accelerator Architecture
-
-### Modes and Features
-
-### Interfaces
-
-### CSR Manager
-
-## Timing Diagrams
-

--- a/docs/tutorial/accelerator_design.md
+++ b/docs/tutorial/accelerator_design.md
@@ -27,7 +27,7 @@ We labeled a few important details about the shell:
 
 You can add your accelerator configurations in a configuration file. The SNAX ALU configuration `snax-alu.hjson` has core templates which configure the Snitch core and how it connects to an accelerator. The `snax-alu` core template is:
 
-```json
+```hjson
 // SNAX Accelerator Core Templates
 snax_alu_core_template: {
     isa: "rv32imafd",

--- a/docs/tutorial/accelerator_design.md
+++ b/docs/tutorial/accelerator_design.md
@@ -13,33 +13,11 @@ We labeled a few important details about the shell:
 
 4 - The accelerator data path is the focus of this section. In our example, we will use a very simple ALU datapath with basic operations only. The SNAX ALU is already built for you. You can find it under the `./hw/snax_alu/` directory. Take time to check the simple design.
 
-# SNAX ALU Accelerator Datapath
 
-The figure below shows the SNAX ALU datapath:
+# SNAX ALU Datapath
 
-Again, we label points of interest:
-
-1 - 
-
-## Accelerator Architecture
-
-## Modes and Features
-
-## Interfaces
-
-## Timing Diagrams
-
-
-
-## TODOs:
-- Describe the accelerator of interest
-- Show a detailed block diagram of the signals
-- Mention and describe what the CSR Manager does
-- Describe the CSRs to be used
-    - Mode: +, -, x, XOR
-    - Data length
-    - Start
-    - Busy
-    - Counter
-- Have a timing diagram interface to describe what happens for the signals
-- Indicate which repository to see this structure
+{%
+   include-markdown '../../hw/snax_alu/doc/snax_alu.md'
+   start="# SNAX ALU Accelerator Datapath"
+   comments=false
+%}

--- a/docs/tutorial/accelerator_design.md
+++ b/docs/tutorial/accelerator_design.md
@@ -21,3 +21,51 @@ We labeled a few important details about the shell:
    start="# SNAX ALU Accelerator Datapath"
    comments=false
 %}
+
+# Adding Your Accelerator to the Configuration File
+
+You can add your accelerator configurations in a configuration file. The SNAX ALU configuration `snax-alu.hjson` has core templates which configure the Snitch core and how it connects to an accelerator. The `snax-alu` core template is:
+
+```json
+// SNAX Accelerator Core Templates
+snax_alu_core_template: {
+    isa: "rv32imafd",
+    xssr: true,
+    xfrep: true,
+    xdma: false,
+    xf16: true,
+    xf16alt: true,
+    xf8: true,
+    xf8alt: true,
+    xfdotp: true,
+    xfvec: true,
+    snax_acc_cfg: {
+        snax_acc_name: "snax_alu"
+        snax_tcdm_ports: 16,
+        snax_num_rw_csr: 3,
+        snax_num_ro_csr: 2,
+        snax_streamer_cfg: {$ref: "#/snax_alu_csr_streamer_template" }
+    },
+    num_int_outstanding_loads: 1,
+    num_int_outstanding_mem: 4,
+    num_fp_outstanding_loads: 4,
+    num_fp_outstanding_mem: 4,
+    num_sequencer_instructions: 16,
+    num_dtlb_entries: 1,
+    num_itlb_entries: 1,
+    // Enable division/square root unit
+    // Xdiv_sqrt: true,
+},
+```
+The first operations before the `snax_acc_cfg` pertain to the Snitch core configurations. Particularly what ISA to use and which additional features it includes. You would usually keep this by default.
+
+The `snax_acc_cfg`  contains the configurations for the accelerator. The configuration definitions are:
+
+- `snax_acc_name`: Is the name appended to the different wrappers discussed in [Connecting the Shell](./connect_shell.md) section.
+- `snax_tcdm_ports`: Is the number of TCDM that your accelerator needs.
+- `snax_num_rw_csr`: Is the number of RW registers your accelerators has. This affects the connection ports of the CSR manager. More details in [SNAX CSR Manager](./csrman_design.md).
+- `snax_num_ro_csr`: Is the number of RO registers your accelerator has. This affects the connection ports CSR manager. More details in [SNAX CSR Manager](./csrman_design.md).
+- `snax_streamer_cfg`: Contains the settings for your streamer. More details are in [SNAX Streamer](./streamer_design.md)
+
+You can find more details in the [Harware Schema](schema-doc/snitch_cluster.md) section. 
+

--- a/docs/tutorial/accelerator_design.md
+++ b/docs/tutorial/accelerator_design.md
@@ -2,6 +2,7 @@
 
 Let's first dive into the SNAX shell which is the encapsulated yellow box from the main figure in [Architectural Overview](./architectural_overview.md). The figure below is the same shell but with more signal details:
 
+![image](https://github.com/KULeuven-MICAS/snitch_cluster/assets/26665295/ea948d6f-44e9-4602-831c-f4ee0d70e851)
 
 We labeled a few important details about the shell:
 

--- a/docs/tutorial/accelerator_design.md
+++ b/docs/tutorial/accelerator_design.md
@@ -63,9 +63,9 @@ The first operations before the `snax_acc_cfg` pertain to the Snitch core config
 The `snax_acc_cfg`  contains the configurations for the accelerator. The configuration definitions are:
 
 - `snax_acc_name`: Is the name appended to the different wrappers discussed in [Connecting the Shell](./connect_shell.md) section.
-- `snax_tcdm_ports`: Is the number of TCDM that your accelerator needs.
-- `snax_num_rw_csr`: Is the number of RW registers your accelerators has. This affects the connection ports of the CSR manager. More details in [SNAX CSR Manager](./csrman_design.md).
-- `snax_num_ro_csr`: Is the number of RO registers your accelerator has. This affects the connection ports CSR manager. More details in [SNAX CSR Manager](./csrman_design.md).
+- `snax_tcdm_ports`: Is the number of tightly coupled data memory (TCDM) that your accelerator needs.
+- `snax_num_rw_csr`: Is the number of read-write (RW) registers your accelerators has. This affects the connection ports of the CSR manager. More details in [SNAX CSR Manager](./csrman_design.md).
+- `snax_num_ro_csr`: Is the number of read-only (RO) registers your accelerator has. This affects the connection ports CSR manager. More details in [SNAX CSR Manager](./csrman_design.md).
 - `snax_streamer_cfg`: Contains the settings for your streamer. More details are in [SNAX Streamer](./streamer_design.md)
 
 You can find more details in the [Harware Schema](schema-doc/snitch_cluster.md) section. 

--- a/docs/tutorial/architectural_overview.md
+++ b/docs/tutorial/architectural_overview.md
@@ -56,7 +56,7 @@ cluster: {
    // Other things below
 ```
 
-Parameters like the `tcdm` configurations indicate the `size` in kB and the number of memory banks. These settings automatically adjust the system. You can find more details in the [Harware Schema](schema-doc/snitch_cluster.md) section. 
+Parameters like the `tcdm` configurations indicate the `size` in kB and the number of memory banks. These settings automatically adjust the system. You can find more details in the [Hardware Schema](schema-doc/snitch_cluster.md) section. 
 
 {%
    include-markdown './accelerator_design.md'

--- a/docs/tutorial/architectural_overview.md
+++ b/docs/tutorial/architectural_overview.md
@@ -41,7 +41,7 @@ In the directory `./target/snitch_cluster/cfg/` you will find several configurat
 
 For example, you would find the cluster or system configuration at the first part:
 
-```json
+```hjson
 cluster: {
    boot_addr: 4096, // 0x1000
    cluster_base_addr: 268435456, // 0x1000_0000

--- a/docs/tutorial/architectural_overview.md
+++ b/docs/tutorial/architectural_overview.md
@@ -31,20 +31,48 @@ As we go through the tutorial, you will see that several of these components are
 
 These are the three major steps that you will see in going through this tutorial. We emphasize that these make it easy for someone new to integrate there accelerator into the system. To give the users a perspective on what they need to work on, we only need the following:
 
-1 - Build your accelerator shell to comply with the control and data interfaces.
+## Building Your Accelerator Shell
 
-- All other connections are provided to you through a wrapper generator we provide to the users. The user only needs to focus on connecting the appropriate signals only.
+The first step is to build your accelerator shell to comply with the control and data interfaces. The [Accelerator Design](./accelerator_design.md) section provides you with a discussion about our example SNAX ALU and the required interfaces. The user only needs to focus on making a shell that connects the appropriate signals for the control and data ports.
 
-2 - Set the system configuration file to the desired customizations.
+## Configuring the System and Accelerators
 
-- Later, there is a configuration file that encompasses all system customizations. This includes the size of the memory, the link for the accelerator to the interconnect, the configurations for the CSR manager and streamer, and so on.
-- A CSR manager is available to handle the control from the Snitch cores and dispatching the configuration registers to the accelerator. The accelerator needs to get the set registers through a decoupled interface. More details are in [CSR Manager Design](./csrman_design.md)
-- A streamer is available for providing reconfigurable and flexible data access from the L1 TCDM to the accelerator. The accelerator needs to comply with the decoupled data interfaces. More details are in [Streamer Design](./streamer_design.md).
+In the directory `./target/snitch_cluster/cfg/` you will find several configurations describing different systems. The `snax-alu.hjson` file contains the configurations we have for the SNAX ALU system (refer to figure above). This configuration file several system customizations. It includes the size of the memory, the connection for the accelerators to the TCDM interconnect, the configurations for the CSR manager and streamer, and so on.
 
-3 - Making the software code and runnning the program.
+For example, you would find the cluster or system configuration at the first part:
 
-- After building the system, we can immediatley test and profile your work through a C-code program. We write CSR functions to configure the accelerator.
+```json
+cluster: {
+   boot_addr: 4096, // 0x1000
+   cluster_base_addr: 268435456, // 0x1000_0000
+   cluster_base_offset: 0,
+   cluster_base_hartid: 0,
+   addr_width: 48,
+   data_width: 64,
+   tcdm: {
+      size: 128,
+      banks: 32,
+   },
+   // Other things below
+```
 
+Parameters like the `tcdm` configurations indicate the `size` in kB and the number of memory banks. These settings automatically adjust the system. You can find more details in the [Harware Schema](schema-doc/snitch_cluster.md) section. 
+
+{%
+   include-markdown './accelerator_design.md'
+   start="# Adding Your Accelerator to the Configuration File"
+   comments=false
+%}
+
+## Configuring the SNAX CSR Manager
+A CSR manager is available to handle the control from the Snitch cores and dispatching the configuration registers to the accelerator. The accelerator needs to get the set registers through a decoupled interface. More details are in [CSR Manager Design](./csrman_design.md)
+
+## Configuring the SNAX Streamer
+A streamer is available for providing reconfigurable and flexible data access from the L1 TCDM to the accelerator. The accelerator needs to comply with the decoupled data interfaces. More details are in [Streamer Design](./streamer_design.md).
+
+## Programming Your Accelerator
+
+After building the system, we can immediatley test and profile your work through a C-code program. We write CSR functions to configure the accelerator. We provide a detail tutorial in [Programming Your Design](./programming.md).
 
 # General Directory Structure
 

--- a/docs/tutorial/architectural_overview.md
+++ b/docs/tutorial/architectural_overview.md
@@ -29,7 +29,7 @@ As we go through the tutorial, you will see that several of these components are
 
 # What Do You Need to Build This System?
 
-These are the three major steps that you will see in going through this tutorial. We emphasize that these make it easy for someone new to integrate there accelerator into the system. To give the users a perspective on what they need to work on, we only need the following:
+These are major steps that you will see in going through this tutorial. We emphasize that these make it easy for someone new to integrate there accelerator into the system. To give the users a perspective on what they need to work on, we only need the following:
 
 ## Building Your Accelerator Shell
 
@@ -65,12 +65,18 @@ Parameters like the `tcdm` configurations indicate the `size` in kB and the numb
 %}
 
 ## Configuring the SNAX CSR Manager
+
 A CSR manager is available to handle the control from the Snitch cores and dispatching the configuration registers to the accelerator. The accelerator needs to get the set registers through a decoupled interface. More details are in [CSR Manager Design](./csrman_design.md)
 
 ## Configuring the SNAX Streamer
+
 A streamer is available for providing reconfigurable and flexible data access from the L1 TCDM to the accelerator. The accelerator needs to comply with the decoupled data interfaces. More details are in [Streamer Design](./streamer_design.md).
 
-## Programming Your Accelerator
+## Building Your System
+
+Building your system is fully-automated by the scripts and makefiles in this platform. As long as you configure your system accordingly, then the entire build process can be excuted with a single `make` command. More details are in the [Building the Architecture](./build_system.md) section.
+
+## Programming Your System
 
 After building the system, we can immediatley test and profile your work through a C-code program. We write CSR functions to configure the accelerator. We provide a detail tutorial in [Programming Your Design](./programming.md).
 

--- a/hw/snax_alu/doc/snax_alu.md
+++ b/hw/snax_alu/doc/snax_alu.md
@@ -2,8 +2,7 @@
 
 The figure below shows the SNAX ALU datapath in more detail:
 
-![image](https://github.com/KULeuven-MICAS/snitch_cluster/assets/26665295/3ec09177-e7ac-4be9-a7b4-60386bc91c62)
-
+![image](https://github.com/KULeuven-MICAS/snitch_cluster/assets/26665295/53d9f0e7-656a-4754-80ac-674d7af9b2f3)
 
 You can find all accelerator files under `./hw/snax_alu/src/.` directory. The main files are:
 

--- a/hw/snax_alu/doc/snax_alu.md
+++ b/hw/snax_alu/doc/snax_alu.md
@@ -16,7 +16,7 @@ Again, we label points of interest with numbers. We facilitate the discussion in
 
 The `snax_alu_pe` is the computing unit of the accelerator. The PE can do addition (+), subtraction (-), multiplication (X), and a bit-wise XOR (^). Each processing element takes in two data inputs, `a` and `b`. Each input with a parameter data width size `DataWidth`. By default `DataWidth=64`. The output is `c` of data width size `2*DataWidth` to accommodate the multiplication. The other operations leave the upper bits to 0.
 
-(2) The inputs and outputs of the PE has a simple decoupled interface (valid-ready protocol). The ports only consists of a single `data` channel. The valid signal of the inputs come from the streamers when data is valid. The ready signal depends on the busy status register. When the valid signals of inputs `a` and `b` are high, then it combinationally sets the valid signal of output `c`. The ready signal of `c` comes from the streamer when it's ready to load data unto the TCDM memory. The entire PE is fully combinational.
+(2) The inputs and outputs of the PE have a simple decoupled interface (valid-ready protocol). The ports only consist of a single `data` channel. The valid signal of the inputs comes from the streamers when the data is valid. The ready signal depends on the busy status register. When the valid signals of inputs `a` and `b` are high, then it combinationally sets the valid signal of output `c`. The ready signal of `c` comes from the streamer when it's ready to load data into the TCDM memory. The entire PE is fully combinational.
 
 ## (3) SNAX ALU CSR Register Set
 
@@ -30,9 +30,9 @@ The `snax_alu_csr` is a control and status register set with signals to modify t
 |    busy         |       3         |   RO    | Busy status. 1 - busy, 0 - idle                     |
 |  perf. counter  |       4         |   RO    | Performance counter indicating number of cycles     |
 
-RW registers can be modified or read from by the CSR manager. These are mostly the configurations and start signals that get to the main data path. The RO registers are read-only register that the CSR manager can read from. These are mostly used for monitoring purposes like status or performance counters.
+RW registers can be modified or read from by the CSR manager. These are mostly the configurations and start signals that get to the main data path. The RO registers are read-only registers that the CSR manager can read from. These are mostly used for monitoring purposes like status or performance counters.
 
-The mode signal is broadcasted to all PEs to configure the kernel that each PE processes. The busy signal acts like an active state also broadcasted to all PEs. If it's high then the PEs set their input ready signals high to allow data to stream continuously. 
+The mode signal is broadcast to all PEs to configure the kernel that each PE processes. The busy signal acts like an active state also broadcasted to all PEs. If it's high then the PEs set their input ready signals high to allow data to stream continuously. 
 
 From the outside, a CSR manager (in this case our SNAX CSR manager) handles the read-and-write transactions from and to the accelerator's CSR register set. The `snax_alu_csr` also uses a decoupled interface but with all RW channels linked to the accelerator. The RO channels are wired directly without any decoupled interface. It is up to the accelerator designer to handle these operations.
 

--- a/hw/snax_alu/doc/snax_alu.md
+++ b/hw/snax_alu/doc/snax_alu.md
@@ -1,23 +1,27 @@
-# SNAX ALU
+# SNAX ALU Accelerator Datapath
 
-This block is a simple ALU accelerator that consists of processing elements that can do +, -, x, and XOR functions. The figure below shows the SNAX ALU architecture:
+The figure below shows the SNAX ALU datapath in more detail:
 
 ![image](https://github.com/KULeuven-MICAS/snitch_cluster/assets/26665295/3ec09177-e7ac-4be9-a7b4-60386bc91c62)
 
 
-# Main Modules
+You can find all accelerator files under `./hw/snax_alu/src/.` directory. The main files are:
 
-The three main modules for the architecture are **SNAX ALU Processing Element**, the **SNAX ALU CSR Register Set**, and the **SNAX Top Level ALU Shell Wrapper**.
+- `snax_alu_pe.sv` as the SNAX ALU Processing Element (PE)
+- `snax_alu_csr.sv` as the main control-status-register (CSR) component
+- `snax_alu_shell_wrapper.sv` as the top-level shell wrapper encapsulating the SNAX PEs, SNAX CSRs, and glue logic to interface between the CSR manager and the SNAX streamer.
 
+Again, we label points of interest with numbers. We facilitate the discussion in a bottom-up approach to see how the accelerator is built:
 
-## SNAX ALU Processing Element
+## (1) SNAX ALU Processing Elements (PE)
 
-The `snax_alu_pe` is the computing unit of the accelerator. Each processing element takes in two data inputs, `a` and `b`, each with a parameter data width size `DataWidth`. The ALU unit can do addition, subtraction, multiplication, and a bit-wise XOR. The output is `c` of data width size `2*DataWidth` to accommodate the multiplication. The other operations leave the upper bits to 0. At the top-most level, these signals are concatenated to accommodate the streamer ports.
+The `snax_alu_pe` is the computing unit of the accelerator. The PE can do addition (+), subtraction (-), multiplication (X), and a bit-wise XOR (^). Each processing element takes in two data inputs, `a` and `b`. Each input with a parameter data width size `DataWidth`. By default `DataWidth=64`. The output is `c` of data width size `2*DataWidth` to accommodate the multiplication. The other operations leave the upper bits to 0.
 
-## SNAX ALU CSR Register Set
+(2) The inputs and outputs of the PE has a simple decoupled interface (valid-ready protocol). The ports only consists of a single `data` channel. The valid signal of the inputs come from the streamers when data is valid. The ready signal depends on the busy status register. When the valid signals of inputs `a` and `b` are high, then it combinationally sets the valid signal of output `c`. The ready signal of `c` comes from the streamer when it's ready to load data unto the TCDM memory. The entire PE is fully combinational.
 
-The `snax_alu_csr` is a control and status register set with signals to modify the operation of the ALU PEs. It also contains a busy status signal and a simple performance counter. The table below shows the register set with addresses, type of register (RW for read-write and RO for read-only), and functional descriptions.
+## (3) SNAX ALU CSR Register Set
 
+The `snax_alu_csr` is a control and status register set with signals to modify the operation of the ALU PEs. It also contains a busy status signal and a simple performance counter. The table below shows the register set with addresses, type of register (`RW` for read-write and `RO` for read-only), and functional descriptions.
 
 |  register name  |  register addr  |   type  |                   description                       |
 | :-------------: | :-------------: | :-----: |:--------------------------------------------------: |
@@ -27,36 +31,63 @@ The `snax_alu_csr` is a control and status register set with signals to modify t
 |    busy         |       3         |   RO    | Busy status. 1 - busy, 0 - idle                     |
 |  perf. counter  |       4         |   RO    | Performance counter indicating number of cycles     |
 
-From the outside, a CSR manager (in this case our SNAX CSR manager) handles the read-and-write transactions from and to the accelerator's CSR register set. The `snax_alu_csr` uses a decoupled interface (valid-ready protocol) but with all RW channels linked to the accelerator. The RO channels are wired directly without any decoupled interface. It is up to the receiving end to handle these operations.
+RW registers can be modified or read from by the CSR manager. These are mostly the configurations and start signals that get to the main data path. The RO registers are read-only register that the CSR manager can read from. These are mostly used for monitoring purposes like status or performance counters.
 
+The mode signal is broadcasted to all PEs to configure the kernel that each PE processes. The busy signal acts like an active state also broadcasted to all PEs. If it's high then the PEs set their input ready signals high to allow data to stream continuously. 
 
-## SNAX Top Level ALU Shell Wrapper
+From the outside, a CSR manager (in this case our SNAX CSR manager) handles the read-and-write transactions from and to the accelerator's CSR register set. The `snax_alu_csr` also uses a decoupled interface but with all RW channels linked to the accelerator. The RO channels are wired directly without any decoupled interface. It is up to the accelerator designer to handle these operations.
 
-The `snax_alu_shell_wrapper` is the all-encompassing top-level wrapper that combines the PEs and the CSR register set. From the CSR manager, we have the RW and RO ports directly connected to the `snax_alu_csr`. For the PEs that connect to an external data streamer, the PE data signals (both input and output) are first concatenated together.
+## (4) SNAX ALU Shell Wrapper
 
-For example, consider the example where we have 4 PEs and each PE can only process `DataWidth` size per port (`2*DataWidth` for the output). Then SNAX streamer uses a data width of `4*DataWidth` for both inputs `A` and `B`. Then we split `A` and `B` contigiously into ports `a` and `b` annotated with numbers from the figure. The output `C` is a concatenation of each `c` port. In Verilog, this is:
+The `snax_alu_shell_wrapper` is the main wrapper for encapsulating the processing elements, the CSR manager, and the glue logic to connect to the streamers. The top-level shell has configurable parameters tabulated below:
+
+|  parameter    |       description                      | default values |
+| :-----------: | :------------------------------------: | :------------: |
+|  RegRWCount   | Number of RW registers                 | 3              |
+|  RegROCount   | Number of RO registers                 | 2              |
+|  NumPE        | Number of parallel PEs                 | 4              |
+|  DataWidth    | INput data width of each PE            | 64             |
+|  OutDataWidth | Output data width of each PE           | DataWidth*2    |
+|  RegDataWidth | Data width of each register            | 32             |
+|  RegAddrwidth | Address width for selecting a register | 32             |
+
+For the CSR side, we have the RW and RO ports directly connecting the `snax_alu_csr` to the CSR manager. The RW ports have a decoupled interface to properly handle the register writes. The RO ports are directly wired to the CSR manager. The shell module's ports for the CSR are:
 
 ```verilog
-  for (int i = 0; i < NumPE; i++) begin
-    // De-concatenating the input signals
-    a_split[i] = stream2acc_0_data_i[i*DataWidth+:DataWidth];
-    b_split[i] = stream2acc_1_data_i[i*DataWidth+:DataWidth];
-
-    // Concatenating the output signals
-    acc2stream_0_data_o[i*DataWidth+:DataWidth] = c_split[i];
-  end
+//-------------------------------
+// CSR manager ports
+//-------------------------------
+input  logic [RegRWCount-1:0][RegDataWidth-1:0] csr_reg_set_i,
+input  logic                                    csr_reg_set_valid_i,
+output logic                                    csr_reg_set_ready_o,
+output logic [RegROCount-1:0][RegDataWidth-1:0] csr_reg_ro_set_o
 ```
-The decoupled control signals are broadcasted and AND'd together. For the input side, all `valid` signals from the streamer to the accelerator input ports are broadcasted, while all `ready` signals are AND'd together. For the output side, all `valid` signals are AND'd towards the streamer and all `ready` signals from the streamer to accelerator PEs are broadcasted. The signals in the figure visualize these.
 
-### Top-level Parameters
+The PEs that connect to an external data streamer have data signals (both input and output) concatenated together. (5) For the PEs that connect to an external data streamer, the PE data signals (both input and output) data channels decoupled interfaces. The module ports are:
 
-The top-level shell has configurable parameters tabulated below:
+```verilog
+//-------------------------------
+// Accelerator ports
+//-------------------------------
+// Note, we maintained the form of these signals
+// just to comply with the top-level wrapper
 
-|  parameter    |       description                      |
-| :-----------: | :------------------------------------: |
-|  RegRWCount   | Number of RW registers                 |
-|  RegROCount   | Number of RO registers                 |
-|  NumPE        | Number of parallel PEs                 |
-|  DataWidth    | Data width of each PE element          |
-|  RegDataWidth | Data width of each register            |
-|  RegAddrwidth | Address width for selecting a register |
+// Ports from accelerator to streamer
+output logic [(NumPE*OutDataWidth)-1:0] acc2stream_0_data_o,
+output logic acc2stream_0_valid_o,
+input  logic acc2stream_0_ready_i,
+
+// Ports from streamer to accelerator
+input  logic [(NumPE*DataWidth)-1:0] stream2acc_0_data_i,
+input  logic stream2acc_0_valid_i,
+output logic stream2acc_0_ready_o,
+
+input  logic [(NumPE*DataWidth)-1:0] stream2acc_1_data_i,
+input  logic stream2acc_1_valid_i,
+output logic stream2acc_1_ready_o,
+
+```
+
+Where `stream2acc` and `acc2stream` indicate the input and output ports respectively. These ports are concatenated signals of the PEs. For example, consider the example where we have `NumPE=4` PEs and each PE can process `DataWidth` size per port (`2*DataWidth` for the output). Then SNAX streamer uses a data width of `4*DataWidth` for both inputs `A` (`stream2acc_0`) and `B` (`stream2acc_1`) . Then we split `A` and `B` contigiously into ports `a` and `b`, respectively. These are annotated with (2) and (5) in the figure. The output `C` is a concatenation of each `c` port. 
+
+Any user attaching their accelerator to the SNAX platform must **create their own shell wrapper** with the correct CSR manager and streamer interfaces. This shell should serve as an example on how to attach the interfaces.


### PR DESCRIPTION
This PR adds the accelerator design section of the convolved tutorial.

Generally, we have:
 - The accelerator details.
 - The updated overview to make the configuration discussion more fluid.

The section discusses:

- [x] Describe the accelerator of interest
  - [x] Discuss the operation it does
  - [x] Discuss the supported CSRs
- [x] Show a block diagram of the signals
- [x] Mention and describe what the CSR Manager does (note more details in other markdown)
- [x] Mention what the streamer does (note more details in other markdown)
- [x] Update SNAX-ALU readme.md
- [x] Introduce the configuration file to use this

The next PRs after this are for the CSR manager and the streamer designs.

